### PR TITLE
feat(ipc): Add IPC listener and act on events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
 name = "assert_cmd"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -111,6 +117,7 @@ dependencies = [
 name = "oniri"
 version = "0.0.1"
 dependencies = [
+ "anyhow",
  "assert_cmd",
  "niri-ipc",
  "predicates",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ license = "GPL-3.0-or-later"
 
 [dependencies]
 niri-ipc = "25.11.0"
+anyhow = "1.0.102"
 
 [dev-dependencies]
 assert_cmd = "2.0.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,11 @@
 // Import modules
 // niri_ipc::* to connect & gather events from niri's IPC socket and act on those
+// For niri_ipc::Output and niri_ipc::state::EventStreamState{,,Part}, see https://github.com/Antiz96/oniri/issues/3
 // std::env to access environment variables & arguments and std::HashMap to create maps
-use niri_ipc::{Event, Request, Response, socket::Socket};
+use niri_ipc::{
+    Event, Output, Request, Response, socket::Socket, state::EventStreamState,
+    state::EventStreamStatePart,
+};
 use std::{collections::HashMap, env};
 
 // Define NAME & VERSION constants, fetched from Cargo metadata
@@ -22,6 +26,21 @@ fn main() -> anyhow::Result<()> {
     // Create a separate socket connection to send actions
     let mut action_socket = Socket::connect()?;
 
+    // Gather the whole state and create an outputs map
+    // This is used later to workaround some limitations of the niri IPC
+    // See https://github.com/Antiz96/oniri/issues/3
+    let mut state = EventStreamState::default();
+    let response = action_socket.send(Request::Outputs)?;
+    let output_list: HashMap<String, Output> = match response {
+        Ok(Response::Outputs(outputs)) => outputs,
+        _ => HashMap::new(),
+    };
+    let mut outputs: HashMap<String, Output> = HashMap::new();
+    for (name, output) in output_list {
+        outputs.insert(name.clone(), output);
+        println!("Registered output: {}", name);
+    }
+
     // Capture events
     if matches!(reply, Ok(Response::Handled)) {
         let mut read_event = event_socket.read_events();
@@ -32,6 +51,8 @@ fn main() -> anyhow::Result<()> {
         // Loop over events and filter the ones about windows being opened or closed
         // Update the window(s)/workspace map when events are matched
         while let Ok(event) = read_event() {
+            state.apply(event.clone()); // https://github.com/Antiz96/oniri/issues/3
+
             match event {
                 Event::WindowOpenedOrChanged { window } => {
                     // Skip floating windows (they cannot/should not be maximized)
@@ -47,9 +68,12 @@ fn main() -> anyhow::Result<()> {
                     for windows in workspace_windows.values() {
                         if windows.len() == 1 {
                             let id = windows[0];
-                            let _ = action_socket
-                                .send(Request::Action(niri_ipc::Action::MaximizeColumn {}));
-                            println!("Maximized window {}", id);
+                            // https://github.com/Antiz96/oniri/issues/3
+                            if !is_maximized(&state, &outputs, id) {
+                                let _ = action_socket
+                                    .send(Request::Action(niri_ipc::Action::MaximizeColumn {}));
+                                println!("Maximized window {}", id);
+                            }
                         }
                     }
                 }
@@ -62,9 +86,12 @@ fn main() -> anyhow::Result<()> {
                     for windows in workspace_windows.values() {
                         if windows.len() == 1 {
                             let id = windows[0];
-                            let _ = action_socket
-                                .send(Request::Action(niri_ipc::Action::MaximizeColumn {}));
-                            println!("Maximized window {}", id);
+                            // https://github.com/Antiz96/oniri/issues/3
+                            if !is_maximized(&state, &outputs, id) {
+                                let _ = action_socket
+                                    .send(Request::Action(niri_ipc::Action::MaximizeColumn {}));
+                                println!("Maximized window {}", id);
+                            }
                         }
                     }
                 }
@@ -74,4 +101,82 @@ fn main() -> anyhow::Result<()> {
         }
     }
     Ok(())
+}
+
+// Hack to determine if a window is supposedly already maximized or not
+// based on a comparison between the window size and the output size.
+// This is to workaround the lack of a window "maximized" state to gather from the IPC,
+// and/or the lack of a way to set/unset the maximize state (rather than just toggling it).
+// See https://github.com/Antiz96/oniri/issues/3 for more details.
+fn is_maximized(
+    state: &EventStreamState,
+    outputs: &HashMap<String, Output>,
+    window_id: u64,
+) -> bool {
+    let tol_w = 150;
+    let tol_h = 150;
+
+    let window = match state.windows.windows.get(&window_id) {
+        Some(w) => w,
+        None => {
+            println!("Window {} not found in state", window_id);
+            return false;
+        }
+    };
+
+    if window.is_floating {
+        println!("Window {} is floating, skipping", window_id);
+        return false;
+    }
+
+    let workspace = match window
+        .workspace_id
+        .and_then(|ws_id| state.workspaces.workspaces.get(&ws_id))
+    {
+        Some(ws) => ws,
+        None => {
+            println!("Workspace for window {} not found", window_id);
+            return false;
+        }
+    };
+
+    let logical = match workspace
+        .output
+        .as_ref()
+        .and_then(|name| outputs.get(name))
+        .and_then(|o| o.logical.as_ref())
+    {
+        Some(l) => l,
+        None => {
+            println!(
+                "Output for workspace {} not found or has no logical size",
+                workspace.id
+            );
+            return false;
+        }
+    };
+
+    let out_w = logical.width as i32;
+    let out_h = logical.height as i32;
+    let (tile_w, tile_h) = window.layout.tile_size;
+    let tile_w = tile_w as i32;
+    let tile_h = tile_h as i32;
+
+    println!(
+        "Window {}: out_w={}, out_h={}, tile_w={}, tile_h={}, tol_w={}, tol_h={}",
+        window_id, out_w, out_h, tile_w, tile_h, tol_w, tol_h
+    );
+
+    let width_ok = (out_w - tile_w).abs() <= tol_w;
+    let height_ok = (out_h - tile_h).abs() <= tol_h;
+
+    println!(
+        "Window {}: width_ok={}, height_ok={}, maximized={}",
+        window_id,
+        width_ok,
+        height_ok,
+        width_ok && height_ok
+    );
+
+    width_ok && height_ok
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,16 +1,77 @@
-// Import the env module to access environment variables and arguments
-use std::env;
+// Import modules
+// niri_ipc::* to connect & gather events from niri's IPC socket and act on those
+// std::env to access environment variables & arguments and std::HashMap to create maps
+use niri_ipc::{Event, Request, Response, socket::Socket};
+use std::{collections::HashMap, env};
 
-// Define NAME & VERSION constant variables, fetched from Cargo metadata
+// Define NAME & VERSION constants, fetched from Cargo metadata
 const NAME: &str = env!("CARGO_PKG_NAME");
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
-fn main() {
-    // Gather the argument passed from the command line
-    let args: Vec<String> = env::args().collect();
-
+fn main() -> anyhow::Result<()> {
     // Print name and version if the -V / --version arg is passed
-    if args.iter().any(|a| a == "-V" || a == "--version") {
+    if env::args().any(|arg| arg == "-V" || arg == "--version") {
         println!("{} {}", NAME, VERSION);
+        return Ok(());
     }
+
+    // Connect to niri IPC socket and start the event stream to gather events
+    let mut event_socket = Socket::connect()?;
+    let reply = event_socket.send(Request::EventStream)?;
+
+    // Create a separate socket connection to send actions
+    let mut action_socket = Socket::connect()?;
+
+    // Capture events
+    if matches!(reply, Ok(Response::Handled)) {
+        let mut read_event = event_socket.read_events();
+
+        // Create a window(s)/workspace map
+        let mut workspace_windows: HashMap<u64, Vec<u64>> = HashMap::new();
+
+        // Loop over events and filter the ones about windows being opened or closed
+        // Update the window(s)/workspace map when events are matched
+        while let Ok(event) = read_event() {
+            match event {
+                Event::WindowOpenedOrChanged { window } => {
+                    // Skip floating windows (they cannot/should not be maximized)
+                    if window.is_floating {
+                        continue;
+                    }
+                    println!("Trigger Event: Window Opened");
+                    let id = window.id;
+                    if let Some(ws) = window.workspace_id {
+                        workspace_windows.entry(ws).or_default().push(id);
+                    }
+                    // Maximize the window if it's the only one
+                    for windows in workspace_windows.values() {
+                        if windows.len() == 1 {
+                            let id = windows[0];
+                            let _ = action_socket
+                                .send(Request::Action(niri_ipc::Action::MaximizeColumn {}));
+                            println!("Maximized window {}", id);
+                        }
+                    }
+                }
+                Event::WindowClosed { id } => {
+                    println!("Trigger Event: Window Closed");
+                    for windows in workspace_windows.values_mut() {
+                        windows.retain(|&wid| wid != id);
+                    }
+                    // Maximize the window if it's the only one
+                    for windows in workspace_windows.values() {
+                        if windows.len() == 1 {
+                            let id = windows[0];
+                            let _ = action_socket
+                                .send(Request::Action(niri_ipc::Action::MaximizeColumn {}));
+                            println!("Maximized window {}", id);
+                        }
+                    }
+                }
+                // Ignore other events
+                _ => {}
+            }
+        }
+    }
+    Ok(())
 }

--- a/tests/version.rs
+++ b/tests/version.rs
@@ -1,4 +1,6 @@
-// Import the assert_cmd and predicates modules to respectively assert on stdout/stderr and check exit codes
+// Import modules
+// assert_cmd::Command to run a command and assert on exit code & stdout/stderr
+// predicates::str::contains to predicate command output
 use assert_cmd::Command;
 use predicates::str::contains;
 


### PR DESCRIPTION
### Description

Add the IPC listener watching for the `WindowOpenedOrChanged` & `WindowClosed` events and act on them by maximizing the only window opened on a workspace.

Note that, due to current niri's IPC limitation, the logic to determine if a window is already maximized is knowingly not elegant and fragile (for the lack of a better option at the moment). See https://github.com/Antiz96/oniri/issues/3 for more details. 