### PR TITLE
feat: Make height and width tolerance configurable

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -62,8 +62,8 @@ fn main() -> anyhow::Result<()> {
                     &workspace_windows,
                     &state,   // https://github.com/Antiz96/oniri/issues/3
                     &outputs, // https://github.com/Antiz96/oniri/issues/3
-                    tol_h, // https://github.com/Antiz96/oniri/issues/3
-                    tol_w, // https://github.com/Antiz96/oniri/issues/3
+                    tol_h,    // https://github.com/Antiz96/oniri/issues/3
+                    tol_w,    // https://github.com/Antiz96/oniri/issues/3
                     &mut action_socket,
                 )?;
             }
@@ -81,8 +81,8 @@ fn main() -> anyhow::Result<()> {
                     &workspace_windows,
                     &state,   // https://github.com/Antiz96/oniri/issues/3
                     &outputs, // https://github.com/Antiz96/oniri/issues/3
-                    tol_h, // https://github.com/Antiz96/oniri/issues/3
-                    tol_w, // https://github.com/Antiz96/oniri/issues/3
+                    tol_h,    // https://github.com/Antiz96/oniri/issues/3
+                    tol_w,    // https://github.com/Antiz96/oniri/issues/3
                     &mut action_socket,
                 )?;
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,6 +23,11 @@ fn main() -> anyhow::Result<()> {
     let mut state = EventStreamState::default();
     let outputs = outputs::outputs_maps(&mut action_socket)?;
 
+    // Set pixel tolerances for window/output size comparison
+    // This can be dropped once https://github.com/Antiz96/oniri/issues/3 is resolved
+    let (tol_h, tol_w) = sizecompare::set_tolerances();
+    println!("Using tolerances: height={}, width={}", tol_h, tol_w);
+
     // Read events gathered from the IPC socket
     let mut read_event = event_socket.read_events();
 
@@ -57,6 +62,8 @@ fn main() -> anyhow::Result<()> {
                     &workspace_windows,
                     &state,   // https://github.com/Antiz96/oniri/issues/3
                     &outputs, // https://github.com/Antiz96/oniri/issues/3
+                    tol_h, // https://github.com/Antiz96/oniri/issues/3
+                    tol_w, // https://github.com/Antiz96/oniri/issues/3
                     &mut action_socket,
                 )?;
             }
@@ -74,6 +81,8 @@ fn main() -> anyhow::Result<()> {
                     &workspace_windows,
                     &state,   // https://github.com/Antiz96/oniri/issues/3
                     &outputs, // https://github.com/Antiz96/oniri/issues/3
+                    tol_h, // https://github.com/Antiz96/oniri/issues/3
+                    tol_w, // https://github.com/Antiz96/oniri/issues/3
                     &mut action_socket,
                 )?;
             }

--- a/src/maximize.rs
+++ b/src/maximize.rs
@@ -11,13 +11,15 @@ pub fn maximize_window_if_alone(
     workspace_windows: &HashMap<u64, Vec<u64>>,
     state: &niri_ipc::state::EventStreamState, // https://github.com/Antiz96/oniri/issues/3
     outputs: &HashMap<String, Output>,         // https://github.com/Antiz96/oniri/issues/3
+    tol_h: i32,                                // https://github.com/Antiz96/oniri/issues/3
+    tol_w: i32,                                // https://github.com/Antiz96/oniri/issues/3
     action_socket: &mut Socket,
 ) -> anyhow::Result<()> {
     for windows in workspace_windows.values() {
         if windows.len() == 1 {
             let id = windows[0];
             // https://github.com/Antiz96/oniri/issues/3
-            if !is_maximized(state, outputs, id) {
+            if !is_maximized(state, outputs, id, tol_h, tol_w) {
                 let _ = action_socket.send(Request::Action(niri_ipc::Action::MaximizeColumn {}));
                 println!("Maximized window {}", id);
             }

--- a/src/sizecompare.rs
+++ b/src/sizecompare.rs
@@ -1,19 +1,53 @@
 // Import external modules
 use niri_ipc::{Output, state::EventStreamState};
-use std::collections::HashMap;
+use std::{collections::HashMap, env};
 
 // Hack to determine if a window is supposedly already maximized or not
 // based on a comparison between the window size and the output size.
 // This is to workaround the lack of a window "maximized" state to gather from the IPC,
 // and/or the lack of a way to set/unset the maximize state (rather than just toggling it).
 // This can be dropped once https://github.com/Antiz96/oniri/issues/3 is resolved.
+
+// Fetch height and width tolerances from CLI, with defaults
+pub fn set_tolerances() -> (i32, i32) {
+    let mut tol_h = 150;
+    let mut tol_w = 150;
+
+    let mut args = env::args();
+    while let Some(arg) = args.next() {
+        match arg.as_str() {
+            "-H" | "--height-tolerance" => {
+                if let Some(value) = args.next() {
+                    if let Ok(val) = value.parse::<i32>() {
+                        tol_h = val;
+                    } else {
+                        eprintln!("Invalid value for {}: {}", arg, value);
+                    }
+                }
+            }
+            "-W" | "--width-tolerance" => {
+                if let Some(value) = args.next() {
+                    if let Ok(val) = value.parse::<i32>() {
+                        tol_w = val;
+                    } else {
+                        eprintln!("Invalid value for {}: {}", arg, value);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    (tol_h, tol_w)
+}
+
 pub fn is_maximized(
     state: &EventStreamState,
     outputs: &HashMap<String, Output>,
     window_id: u64,
+    tol_w: i32,
+    tol_h: i32,
 ) -> bool {
-    let tol_w = 150;
-    let tol_h = 150;
 
     let window = match state.windows.windows.get(&window_id) {
         Some(w) => w,

--- a/src/sizecompare.rs
+++ b/src/sizecompare.rs
@@ -48,7 +48,6 @@ pub fn is_maximized(
     tol_w: i32,
     tol_h: i32,
 ) -> bool {
-
     let window = match state.windows.windows.get(&window_id) {
         Some(w) => w,
         None => {


### PR DESCRIPTION
### Description

Introduce the (optional) `-H / --height-tolerance` and `-W / --width-tolerance` CLI arguments to configure the tolerance (in pixels) for the window/output size comparison when trying to determine if a window is already maximized or not.

This is a temporary workaround to offer some flexibility to users regarding the limitations of the niri IPC exposed in https://github.com/Antiz96/oniri/issues/3.