### PR TITLE
fix: Initialize workspace/window(s) map after creation

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,11 @@
 // Import external modules
 use niri_ipc::{Event, state::EventStreamState, state::EventStreamStatePart};
-use std::collections::HashMap;
 
 // Import internal modules
 mod firstonly;
 mod maximize;
-mod outputs; // https://github.com/Antiz96/oniri/issues/3
+mod windowsmap;
+mod outputsmap; // https://github.com/Antiz96/oniri/issues/3
 mod sizecompare; // https://github.com/Antiz96/oniri/issues/3
 mod socket;
 mod version;
@@ -34,13 +34,13 @@ fn main() -> anyhow::Result<()> {
     // Gather state and create an outputs map
     // This can be dropped once https://github.com/Antiz96/oniri/issues/3 is resolved
     let mut state = EventStreamState::default();
-    let outputs = outputs::outputs_maps(&mut action_socket)?;
+    let outputs = outputsmap::outputs_map(&mut action_socket)?;
+
+    // Create a workspace/window(s) map and intialize it
+    let mut workspace_windows = windowsmap::windows_map(&mut action_socket)?;
 
     // Read events gathered from the IPC socket
     let mut read_event = event_socket.read_events();
-
-    // Create a workspace/window(s) map
-    let mut workspace_windows: HashMap<u64, Vec<u64>> = HashMap::new();
 
     // Loop over events
     while let Ok(event) = read_event() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,7 +36,7 @@ fn main() -> anyhow::Result<()> {
     let mut state = EventStreamState::default();
     let outputs = outputsmap::outputs_map(&mut action_socket)?;
 
-    // Create a workspace/window(s) map and intialize it
+    // Create a workspace/window(s) map and initialize it
     let mut workspace_windows = windowsmap::windows_map(&mut action_socket)?;
 
     // Read events gathered from the IPC socket

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,11 +4,11 @@ use niri_ipc::{Event, state::EventStreamState, state::EventStreamStatePart};
 // Import internal modules
 mod firstonly;
 mod maximize;
-mod windowsmap;
 mod outputsmap; // https://github.com/Antiz96/oniri/issues/3
 mod sizecompare; // https://github.com/Antiz96/oniri/issues/3
 mod socket;
 mod version;
+mod windowsmap;
 
 fn main() -> anyhow::Result<()> {
     // Show name and version if the -V / --version arg is passed

--- a/src/outputsmap.rs
+++ b/src/outputsmap.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 // Create an outputs map, used later for window/output size comparison,
 // used as a workaround for some limitations of the niri IPC
 // This can be dropped once https://github.com/Antiz96/oniri/issues/3 is solved
-pub fn outputs_maps(action_socket: &mut Socket) -> anyhow::Result<HashMap<String, Output>> {
+pub fn outputs_map(action_socket: &mut Socket) -> anyhow::Result<HashMap<String, Output>> {
     let response = action_socket.send(Request::Outputs)?;
 
     let outputs = match response {

--- a/src/windowsmap.rs
+++ b/src/windowsmap.rs
@@ -2,7 +2,7 @@
 use niri_ipc::{Request, Response, socket::Socket};
 use std::collections::HashMap;
 
-// Create a workspace/window(s) map and intialize it
+// Create a workspace/window(s) map and initialize it
 pub fn windows_map(
     action_socket: &mut Socket,
 ) -> anyhow::Result<HashMap<u64, Vec<u64>>> {

--- a/src/windowsmap.rs
+++ b/src/windowsmap.rs
@@ -1,0 +1,30 @@
+// Import external modules
+use niri_ipc::{Request, Response, socket::Socket};
+use std::collections::HashMap;
+
+// Create a workspace/window(s) map and intialize it
+pub fn windows_map(
+    action_socket: &mut Socket,
+) -> anyhow::Result<HashMap<u64, Vec<u64>>> {
+
+    let response = action_socket.send(Request::Windows)?;
+
+    let Ok(Response::Windows(windows)) = response else {
+        return Ok(HashMap::new());
+    };
+
+    let mut workspace_windows: HashMap<u64, Vec<u64>> = HashMap::new();
+
+    for window in windows {
+        // Skip floating windows (they cannot/should not be maximized)
+        if window.is_floating {
+            continue;
+        }
+
+        if let Some(ws) = window.workspace_id {
+            workspace_windows.entry(ws).or_default().push(window.id);
+        }
+    }
+
+    Ok(workspace_windows)
+}

--- a/src/windowsmap.rs
+++ b/src/windowsmap.rs
@@ -3,10 +3,7 @@ use niri_ipc::{Request, Response, socket::Socket};
 use std::collections::HashMap;
 
 // Create a workspace/window(s) map and initialize it
-pub fn windows_map(
-    action_socket: &mut Socket,
-) -> anyhow::Result<HashMap<u64, Vec<u64>>> {
-
+pub fn windows_map(action_socket: &mut Socket) -> anyhow::Result<HashMap<u64, Vec<u64>>> {
     let response = action_socket.send(Request::Windows)?;
 
     let Ok(Response::Windows(windows)) = response else {


### PR DESCRIPTION
### Description

Initialize workspace/window(s) map after creation so it's up to date right away, in order to avoid eventual false positives (e.g. in case `oniri` is started after some windows are already opened).

Also, move the workspace/window(s) map initialization to its use separate file / modules.