### PR TITLE
chore: Update release script to avoid bumping dependencies version unexpectedly

### DIFF
--- a/scripts/mkrelease.sh
+++ b/scripts/mkrelease.sh
@@ -42,7 +42,7 @@ esac
 
 # Bump version where necessary
 sed_pattern="${latest_tag//./\\.}" # escape dots
-sed -i "s/${sed_pattern#v}/${release_tag}/g" Cargo.toml doc/man/oniri.1.scd
+sed -i "s/version = ${sed_pattern#v}/version = ${release_tag}/g" Cargo.toml doc/man/oniri.1.scd
 
 # Build binary
 rm -rf target/ && cargo build --release


### PR DESCRIPTION
### Description

Update release script to adopt a more robust / precise pattern when bumping oniri's version in Cargo.toml to avoid bumping dependencies version unexpectedly.