### PR TITLE
fix(event): Prevent duplicate windows in the workspace map

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -82,7 +82,10 @@ fn main() -> anyhow::Result<()> {
                 // Update the workspace/window(s) map
                 let id = window.id;
                 if let Some(ws) = window.workspace_id {
-                    workspace_windows.entry(ws).or_default().push(id);
+                    let entry = workspace_windows.entry(ws).or_default();
+                    if !entry.contains(&id) {
+                        entry.push(id);
+                    }
                 }
 
                 // Check if there's only one window in the workspace/window(s) map & maximize it if so


### PR DESCRIPTION
<!-- Please, read the contributing guidelines before opening a pull request: https://github.com/Antiz96/arch-update/blob/main/CONTRIBUTING.md -->

### Description

<!-- Describe your changes -->

For each window, Event::WindowOpenedOrChanged will always trigger twice. This means all windows opened after the initial workspace map will have duplicate ids in the workspace map.

Do not insert the window into the workspace map if it is already present. This fixes maximizing the last window after every other window is closed, before it would behave the same as with -F.

### Screenshots / Logs

<!-- If you have any screenshots to illustrate your changes or any relevant logs, paste them below -->

```text
Paste any relevant logs here (if you have some)
```

### Fixed bug

<!-- If this pull request is fixing an opened bug report, paste the corresponding issue URL below -->

Fixes "issue_URL" (if any)

### Addressed feature request

<!-- If this pull request is addressing an opened feature request, paste the corresponding issue URL below -->

Closes "issue_URL" (if any)

