### PR TITLE
refactor(maximize_window): Only maximize windows on one workspace

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -85,15 +85,18 @@ fn main() -> anyhow::Result<()> {
                     windows.retain(|&wid| wid != id);
                 }
 
-                if let Some(ws) = window.workspace_id {
-                    let entry = workspace_windows.entry(ws).or_default();
-                    if !entry.contains(&id) {
-                        entry.push(id);
-                    }
+                let Some(ws) = window.workspace_id else {
+                    continue;
+                };
+
+                let entry = workspace_windows.entry(ws).or_default();
+                if !entry.contains(&id) {
+                    entry.push(id);
                 }
 
                 // Check if there's only one window in the workspace/window(s) map & maximize it if so
                 maximize_window::maximize_window_if_alone(
+                    ws,
                     &workspace_windows,
                     &state,   // https://github.com/Antiz96/oniri/issues/3
                     &outputs, // https://github.com/Antiz96/oniri/issues/3
@@ -106,8 +109,15 @@ fn main() -> anyhow::Result<()> {
             Event::WindowClosed { id } => {
                 debug!("Trigger Event: Window Closed");
 
+                let Some(ws) = workspace_windows
+                    .iter()
+                    .find_map(|(&ws, windows)| windows.contains(&id).then_some(ws))
+                else {
+                    continue;
+                };
+
                 // Update the workspace/window(s) map
-                for windows in workspace_windows.values_mut() {
+                if let Some(windows) = workspace_windows.get_mut(&ws) {
                     windows.retain(|&wid| wid != id);
                 }
 
@@ -118,6 +128,7 @@ fn main() -> anyhow::Result<()> {
 
                 // Check if there's only one window in the workspace/window(s) map & maximize it if so
                 maximize_window::maximize_window_if_alone(
+                    ws,
                     &workspace_windows,
                     &state,   // https://github.com/Antiz96/oniri/issues/3
                     &outputs, // https://github.com/Antiz96/oniri/issues/3

--- a/src/maximize_window.rs
+++ b/src/maximize_window.rs
@@ -10,6 +10,7 @@ use std::collections::HashMap;
 use crate::size_compare::is_maximized; // https://github.com/Antiz96/oniri/issues/3
 
 pub fn maximize_window_if_alone(
+    workspace_id: u64,
     workspace_windows: &HashMap<u64, Vec<u64>>,
     state: &niri_ipc::state::EventStreamState, // https://github.com/Antiz96/oniri/issues/3
     outputs: &HashMap<String, Output>,         // https://github.com/Antiz96/oniri/issues/3
@@ -17,16 +18,21 @@ pub fn maximize_window_if_alone(
     tol_w: i32,                                // https://github.com/Antiz96/oniri/issues/3
     action_socket: &mut Socket,
 ) -> anyhow::Result<()> {
-    for windows in workspace_windows.values() {
-        if windows.len() == 1 {
-            let id = windows[0];
-            // https://github.com/Antiz96/oniri/issues/3
-            if !is_maximized(state, outputs, id, tol_h, tol_w) {
-                let _ = action_socket.send(Request::Action(niri_ipc::Action::FocusWindow { id }));
-                let _ = action_socket.send(Request::Action(niri_ipc::Action::MaximizeColumn {}));
-                info!("Maximized window {}", id);
-            }
-        }
+    let Some(windows) = workspace_windows.get(&workspace_id) else {
+        return Ok(());
+    };
+
+    if windows.len() != 1 {
+        return Ok(());
     }
+
+    let id = windows[0];
+    // https://github.com/Antiz96/oniri/issues/3
+    if !is_maximized(state, outputs, id, tol_h, tol_w) {
+        let _ = action_socket.send(Request::Action(niri_ipc::Action::FocusWindow { id }));
+        let _ = action_socket.send(Request::Action(niri_ipc::Action::MaximizeColumn {}));
+        info!("Maximized window {}", id);
+    }
+
     Ok(())
 }


### PR DESCRIPTION


<!-- Please, read the contributing guidelines before opening a pull request: https://github.com/Antiz96/arch-update/blob/main/CONTRIBUTING.md -->

### Description

<!-- Describe your changes -->
Currently maximize_window_if_alone() will always iterate through all workspaces when an event is triggered. This is bad in two ways:
1. Pointless work when there are many workspaces
2. Maximizing a window that is not expected by the user: say we have a single window in a workspace that is not maximized, opening a new window in a new workspace will maximize both the new window and the other window in another workspace.

Only maximize windows on one workspace so that behaviour is more predictable.

### Screenshots / Logs

<!-- If you have any screenshots to illustrate your changes or any relevant logs, paste them below -->

```text
Paste any relevant logs here (if you have some)
```

### Fixed bug

<!-- If this pull request is fixing an opened bug report, paste the corresponding issue URL below -->

Fixes "issue_URL" (if any)

### Addressed feature request

<!-- If this pull request is addressing an opened feature request, paste the corresponding issue URL below -->

Closes "issue_URL" (if any)

