### PR TITLE
fix(nautilus): Skip parsing Nautilus when it is in loading state

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -77,6 +77,17 @@ fn main() -> anyhow::Result<()> {
                     continue;
                 }
 
+                // On first launch, nautilus will first enter this loading state and defer
+                // maximize_window() until after the window spawns. This will cause
+                // Action::MaximizeColumn to run twice on the same window, and basically noop.
+                //
+                // This can be dropped once https://github.com/Antiz96/oniri/issues/3 is resolved.
+                if window.app_id.unwrap_or_default() == "org.gnome.Nautilus"
+                    && window.title.unwrap_or_default() == "Loading…"
+                {
+                    continue;
+                }
+
                 debug!("Trigger Event: Window Opened Or Changed");
 
                 let id = window.id;


### PR DESCRIPTION


<!-- Please, read the contributing guidelines before opening a pull request: https://github.com/Antiz96/arch-update/blob/main/CONTRIBUTING.md -->

### Description

<!-- Describe your changes -->
There is a race condition with Nautilus that makes it defer the first maximize_window() to until the window actually spawns. This causes two maximize_window() actions to act on the same window, negating the effect and causing nothing to happen.

As a hack, just skip parsing Nautilus entirely when it is loading. As of writing, there is no better way to fix this without rewriting the code base and potentially making things uglier.

### Screenshots / Logs

<!-- If you have any screenshots to illustrate your changes or any relevant logs, paste them below -->

```text
Paste any relevant logs here (if you have some)
```

### Fixed bug

<!-- If this pull request is fixing an opened bug report, paste the corresponding issue URL below -->

Fixes "issue_URL" (if any)

### Addressed feature request

<!-- If this pull request is addressing an opened feature request, paste the corresponding issue URL below -->

Closes "issue_URL" (if any)

