### PR TITLE
feat: Add the `-E / --edges-maximizing` option

### DIFF
--- a/doc/man/oniri.1.scd
+++ b/doc/man/oniri.1.scd
@@ -20,6 +20,9 @@ Oniri is a tool that automatically maximizes the *on*ly window of a *niri* works
 *-T, --tiling-layout*
 	Unmaximize the first window when opening a second one, like in a tiling compositor.
 
+*-E, --edges-maximizing*
+	Maximize windows to edges.
+
 *-H, --height-tolerance* <number>
 	Set the height size tolerance (in pixels) when comparing the window size to the output size to determine if the window is maximized or not (https://github.com/Antiz96/oniri/issues/3).
 

--- a/res/completions/oniri.bash
+++ b/res/completions/oniri.bash
@@ -3,6 +3,7 @@ _oniri() {
 	local -a opts
 	opts=('-F --first-only
 	       -T --tiling-layout
+	       -E --edges-maximizing
 	       -H --height-tolerance
 	       -W --width-tolerance
 	       -h --help

--- a/res/completions/oniri.fish
+++ b/res/completions/oniri.fish
@@ -2,6 +2,7 @@ complete -c oniri -f
 
 complete -c oniri -s F -l first-only -d 'Only maximize the first window opened, do no act on the last remaining one'
 complete -c oniri -s T -l tiling-layout -d 'Unmaximize the first window when opening a second one, like in a tiling compositor'
+complete -c oniri -s E -l edges-maximizing -d 'Maximize windows to edges'
 complete -c oniri -s H -l height-tolerance -d 'Set the height size tolerance (in pixels) when comparing the window size to the output size to determine if the window is maximized or not'
 complete -c oniri -s W -l width-tolerance -d 'Set the width size tolerance (in pixels) when comparing the window size to the output size to determine if the window is maximized or not'
 complete -c oniri -s h -l help -d 'Display the help message'

--- a/res/completions/oniri.zsh
+++ b/res/completions/oniri.zsh
@@ -4,6 +4,7 @@ local -a opts
 opts=(
     {-F,--first-only}'[Only maximize the first window opened, do no act on the last remaining one]'
     {-T,--tiling-layout}'[Unmaximize the first window when opening a second one, like in a tiling compositor]'
+    {-E,--edges-maximizing}'[Maximize windows to edges]'
     {-H,--height-tolerance}'[Set the height size tolerance (in pixels) when comparing the window size to the output size to determine if the window is maximized or not]'
     {-W,--width-tolerance}'[Set the width size tolerance (in pixels) when comparing the window size to the output size to determine if the window is maximized or not]'
     {-h,--help}'[Display the help message]'

--- a/src/help.rs
+++ b/src/help.rs
@@ -15,6 +15,7 @@ pub fn show_help() {
     println!(
         "  -T, --tiling-layout     Unmaximize the first window when opening a second one, like in a tiling compositor"
     );
+    println!("  -E, --edges-maximizing     Maximize windows to edges");
     println!(
         "  -H, --height-tolerance  Set the height size tolerance (in pixels) when comparing the window size to the output size to determine if the window is maximized or not" // https://github.com/Antiz96/oniri/issues/3
     );

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,6 +53,14 @@ fn main() -> anyhow::Result<()> {
         );
     }
 
+    // Run in "maximizing-to-edges" mode if the -E / --edges-maximizing arg is passed
+    let edges_maximizing = has_arg("-E") || has_arg("--edges-maximizing");
+    if edges_maximizing {
+        info!(
+            "Running in maximize-to-edges mode: Maximize windows to edges"
+        );
+    }
+
     // Set pixel tolerances for window/output size comparison
     // This can be dropped once https://github.com/Antiz96/oniri/issues/3 is resolved
     let (tol_h, tol_w) = size_compare::set_tolerances();
@@ -118,7 +126,7 @@ fn main() -> anyhow::Result<()> {
                     1 => {
                         let first_window = windows[0];
                         if !is_maximized(&state, &outputs, first_window, tol_h, tol_w) {
-                            maximize_window(&mut action_socket, &state, first_window)?;
+                            maximize_window(&mut action_socket, &state, first_window, edges_maximizing)?;
                         }
                     }
 
@@ -126,7 +134,7 @@ fn main() -> anyhow::Result<()> {
                     2 if tiling_layout => {
                         let first_window = windows[0];
                         if is_maximized(&state, &outputs, first_window, tol_h, tol_w) {
-                            maximize_window(&mut action_socket, &state, first_window)?;
+                            maximize_window(&mut action_socket, &state, first_window, edges_maximizing)?;
                         }
                     }
                     _ => {}
@@ -158,7 +166,7 @@ fn main() -> anyhow::Result<()> {
 
                 let id = windows[0];
                 if !is_maximized(&state, &outputs, id, tol_h, tol_w) {
-                    maximize_window(&mut action_socket, &state, id)?;
+                    maximize_window(&mut action_socket, &state, id, edges_maximizing)?;
                 }
             }
             // Ignore other events

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,9 +56,7 @@ fn main() -> anyhow::Result<()> {
     // Run in "maximizing-to-edges" mode if the -E / --edges-maximizing arg is passed
     let edges_maximizing = has_arg("-E") || has_arg("--edges-maximizing");
     if edges_maximizing {
-        info!(
-            "Running in maximize-to-edges mode: Maximize windows to edges"
-        );
+        info!("Running in maximize-to-edges mode: Maximize windows to edges");
     }
 
     // Set pixel tolerances for window/output size comparison
@@ -126,7 +124,12 @@ fn main() -> anyhow::Result<()> {
                     1 => {
                         let first_window = windows[0];
                         if !is_maximized(&state, &outputs, first_window, tol_h, tol_w) {
-                            maximize_window(&mut action_socket, &state, first_window, edges_maximizing)?;
+                            maximize_window(
+                                &mut action_socket,
+                                &state,
+                                first_window,
+                                edges_maximizing,
+                            )?;
                         }
                     }
 
@@ -134,7 +137,12 @@ fn main() -> anyhow::Result<()> {
                     2 if tiling_layout => {
                         let first_window = windows[0];
                         if is_maximized(&state, &outputs, first_window, tol_h, tol_w) {
-                            maximize_window(&mut action_socket, &state, first_window, edges_maximizing)?;
+                            maximize_window(
+                                &mut action_socket,
+                                &state,
+                                first_window,
+                                edges_maximizing,
+                            )?;
                         }
                     }
                     _ => {}

--- a/src/maximize_window.rs
+++ b/src/maximize_window.rs
@@ -12,11 +12,9 @@ pub fn maximize_window(
     edges_maximizing: bool,
 ) -> anyhow::Result<()> {
     if edges_maximizing {
-        let _ = socket.send(Request::Action(
-            niri_ipc::Action::MaximizeWindowToEdges {
-                id: Some(window_id),
-            },
-        ));
+        let _ = socket.send(Request::Action(niri_ipc::Action::MaximizeWindowToEdges {
+            id: Some(window_id),
+        }));
         info!("Maximized window to edges {}", window_id);
     } else {
         // We need this information to restore focus state after maximizing @window_id

--- a/src/maximize_window.rs
+++ b/src/maximize_window.rs
@@ -9,24 +9,34 @@ pub fn maximize_window(
     socket: &mut Socket,
     state: &EventStreamState,
     window_id: u64,
+    edges_maximizing: bool,
 ) -> anyhow::Result<()> {
-    // We need this information to restore focus state after maximizing @window_id
-    let Some(focused_id) = state
-        .windows
-        .windows
-        .values()
-        .find_map(|window| window.is_focused.then_some(window.id))
-    else {
-        return Ok(());
-    };
+    if edges_maximizing {
+        let _ = socket.send(Request::Action(
+            niri_ipc::Action::MaximizeWindowToEdges {
+                id: Some(window_id),
+            },
+        ));
+        info!("Maximized window to edges {}", window_id);
+    } else {
+        // We need this information to restore focus state after maximizing @window_id
+        let Some(focused_id) = state
+            .windows
+            .windows
+            .values()
+            .find_map(|window| window.is_focused.then_some(window.id))
+        else {
+            return Ok(());
+        };
 
-    let _ = socket.send(Request::Action(niri_ipc::Action::FocusWindow {
-        id: window_id,
-    }));
-    let _ = socket.send(Request::Action(niri_ipc::Action::MaximizeColumn {}));
-    let _ = socket.send(Request::Action(niri_ipc::Action::FocusWindow {
-        id: focused_id,
-    }));
-    info!("Maximized window {}", window_id);
+        let _ = socket.send(Request::Action(niri_ipc::Action::FocusWindow {
+            id: window_id,
+        }));
+        let _ = socket.send(Request::Action(niri_ipc::Action::MaximizeColumn {}));
+        let _ = socket.send(Request::Action(niri_ipc::Action::FocusWindow {
+            id: focused_id,
+        }));
+        info!("Maximized window {}", window_id);
+    }
     Ok(())
 }


### PR DESCRIPTION
### Description

Add the new `-E / --edges-maximizing` option to maximize windows to edges (instead of maximizing the column "normally").

### Addressed feature request

Closes https://github.com/Antiz96/oniri/issues/37

