### PR TITLE
fix: Track and act on the previous workspace after the active window is moved to another one

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -106,9 +106,9 @@ fn main() -> anyhow::Result<()> {
                 // If not, track the previous workspace to act on it (if needed), for instance if the current
                 // window is moved to another workspace and there's only one window remaining on the
                 // previous one (which should therefore be maximized).
-                let previous_ws = workspace_windows.iter().find_map(|(&tracked_ws, windows)| {
-                    windows.contains(&id).then_some(tracked_ws)
-                });
+                let previous_ws = workspace_windows
+                    .iter()
+                    .find_map(|(&tracked_ws, windows)| windows.contains(&id).then_some(tracked_ws));
 
                 if previous_ws == Some(ws) {
                     continue;
@@ -152,23 +152,16 @@ fn main() -> anyhow::Result<()> {
                 }
 
                 // If the window that triggered the event has been moved to another workspace, then
-		// check if there's only one window in the previous workspace & maximize it if so.
-                if let Some(old_ws) = previous_ws {
-                    if old_ws != ws {
-                        if let Some(old_windows) = workspace_windows.get(&old_ws) {
-                            if old_windows.len() == 1 {
-                                let remaining = old_windows[0];
+                // check if there's only one window in the previous workspace & maximize it if so.
+                if let Some(old_ws) = previous_ws
+                    && old_ws != ws
+                    && let Some(old_windows) = workspace_windows.get(&old_ws)
+                    && old_windows.len() == 1
+                {
+                    let remaining = old_windows[0];
 
-                                if !is_maximized(&state, &outputs, remaining, tol_h, tol_w) {
-                                    maximize_window(
-                                        &mut action_socket,
-                                        &state,
-                                        remaining,
-                                        edges_maximizing,
-                                    )?;
-                                }
-                            }
-                        }
+                    if !is_maximized(&state, &outputs, remaining, tol_h, tol_w) {
+                        maximize_window(&mut action_socket, &state, remaining, edges_maximizing)?;
                     }
                 }
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -152,8 +152,10 @@ fn main() -> anyhow::Result<()> {
                 }
 
                 // If the window that triggered the event has been moved to another workspace, then
-                // check if there's only one window in the previous workspace & maximize it if so.
+                // check if there's only one window in the previous workspace & maximize it if so (unless we're running
+                // in "first-only" mode).
                 if let Some(old_ws) = previous_ws
+                    && !first_only
                     && old_ws != ws
                     && let Some(old_windows) = workspace_windows.get(&old_ws)
                     && old_windows.len() == 1

--- a/src/main.rs
+++ b/src/main.rs
@@ -103,11 +103,14 @@ fn main() -> anyhow::Result<()> {
                 // Workaround IPC limitation by checking if the window that triggered the event is
                 // in the same workspace.
                 //
-                // This will differentiate between WindowOpened and WindowChanged.
-                if workspace_windows
-                    .get(&ws)
-                    .is_some_and(|windows| windows.contains(&id))
-                {
+                // If not, track the previous workspace to act on it (if needed), for instance if the current
+                // window is moved to another workspace and there's only one window remaining on the
+                // previous one (which should therefore be maximized).
+                let previous_ws = workspace_windows.iter().find_map(|(&tracked_ws, windows)| {
+                    windows.contains(&id).then_some(tracked_ws)
+                });
+
+                if previous_ws == Some(ws) {
                     continue;
                 }
 
@@ -119,7 +122,7 @@ fn main() -> anyhow::Result<()> {
                 let windows = workspace_windows.entry(ws).or_default();
                 windows.push(id);
 
-                // Check if there's only one window in the workspace/window(s) map & maximize it if so
+                // Check if there's only one window in the current workspace & maximize it if so
                 match windows.len() {
                     1 => {
                         let first_window = windows[0];
@@ -147,7 +150,29 @@ fn main() -> anyhow::Result<()> {
                     }
                     _ => {}
                 }
+
+                // If the window that triggered the event has been moved to another workspace, then
+		// check if there's only one window in the previous workspace & maximize it if so.
+                if let Some(old_ws) = previous_ws {
+                    if old_ws != ws {
+                        if let Some(old_windows) = workspace_windows.get(&old_ws) {
+                            if old_windows.len() == 1 {
+                                let remaining = old_windows[0];
+
+                                if !is_maximized(&state, &outputs, remaining, tol_h, tol_w) {
+                                    maximize_window(
+                                        &mut action_socket,
+                                        &state,
+                                        remaining,
+                                        edges_maximizing,
+                                    )?;
+                                }
+                            }
+                        }
+                    }
+                }
             }
+
             // Window being closed
             Event::WindowClosed { id } => {
                 debug!("Trigger Event: Window Closed");

--- a/src/main.rs
+++ b/src/main.rs
@@ -106,6 +106,8 @@ fn main() -> anyhow::Result<()> {
                 // If not, track the previous workspace to act on it (if needed), for instance if the current
                 // window is moved to another workspace and there's only one window remaining on the
                 // previous one (which should therefore be maximized).
+                //
+                // This will differentiate between WindowOpened and WindowChanged.
                 let previous_ws = workspace_windows
                     .iter()
                     .find_map(|(&tracked_ws, windows)| windows.contains(&id).then_some(tracked_ws));
@@ -152,8 +154,8 @@ fn main() -> anyhow::Result<()> {
                 }
 
                 // If the window that triggered the event has been moved to another workspace, then
-                // check if there's only one window in the previous workspace & maximize it if so (unless we're running
-                // in "first-only" mode).
+                // check if there's only one window in the previous workspace & maximize it if so
+                // (unless we're running in "first-only" mode).
                 if let Some(old_ws) = previous_ws
                     && !first_only
                     && old_ws != ws


### PR DESCRIPTION
### Description

When a window is being moved from one workspace to another, track the "previous" workspace and also act on it if needed.  
For instance, if the active window is moved to another workspace and there's only one window remaining on the previous one, also maximize this window (unless if running in "first-only" mode).

### Fixed bug

Fixes https://github.com/Antiz96/oniri/issues/42
