### PR TITLE
chore(renovate): Enable lockfile maintenance

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,6 +2,7 @@
   "dependencyDashboard": false,
   "assignees": ["Antiz96"],
   "git-submodules": { "enabled": true },
+  "lockFileMaintenance": { "enabled": true },
   "commitMessagePrefix": "chore(deps): ",
   "commitMessageAction": "update",
   "commitMessageTopic": "{{depName}}",


### PR DESCRIPTION
### Description

Enable lockfile maintenance in renovate so that all dependencies are tracked & updated in Cargo.lock (including transitives ones, not only direct ones).  
See https://docs.renovatebot.com/configuration-options/#lockfilemaintenance