### PR TITLE
chore(renovate): Relax schedule for lockfile maintenance

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,7 +2,7 @@
   "dependencyDashboard": false,
   "assignees": ["Antiz96"],
   "git-submodules": { "enabled": true },
-  "lockFileMaintenance": { "enabled": true },
+  "lockFileMaintenance": { "enabled": true, "schedule": ["at any time"] },
   "commitMessagePrefix": "chore(deps): ",
   "commitMessageAction": "update",
   "commitMessageTopic": "{{depName}}",


### PR DESCRIPTION
### Description

Renovate performs lockFileMaintenance 'before 4am on monday' by default. Let's relax the schedule so it's triggered every time.

If it becomes too noisy, I'll remove the schedule relaxing.