### PR TITLE
chore(release): Use repro-env to build release binary

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,7 +4,7 @@
 
 - `git-cliff`
 - `github-cli`
-- `cargo`
+- `repro-env`
 
 ## Disable the main branch protection rule temporarily
 

--- a/repro-env.lock
+++ b/repro-env.lock
@@ -1,0 +1,107 @@
+[container]
+image = "docker.io/archlinux/archlinux@sha256:e686f41388b64360807b7f14b5535187baa5ffaea6646c857b1c8f2b17a0b1f9"
+
+[[package]]
+name = "compiler-rt"
+version = "22.1.5-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/c/compiler-rt/compiler-rt-22.1.5-1-x86_64.pkg.tar.zst"
+sha256 = "247d72e99e3ebbd46f8e14e162a6d162bdfcedf500af61b5a426aaab668e5320"
+signature = "iHUEABYKAB0WIQTS6V/sAVzx+RGqqww9TFAIu1yNKQUCafy6uwAKCRA9TFAIu1yNKW0eAQCtpYK/Klh3WdzGiDlzLd9IIQ/JoKHpUSJJWgEw24dXvQD9E9ZycrdYnou5D7fiNRW/QdjhnZasOGOQTLpR5OYcTgA="
+
+[[package]]
+name = "curl"
+version = "8.20.0-7"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/c/curl/curl-8.20.0-7-x86_64.pkg.tar.zst"
+sha256 = "9a09dc5796e83f129d032b1d831a85b276f8fba50f430ba143993a9ed02351c1"
+signature = "iHUEABYKAB0WIQQhkbiUMbrAqLlt6T0kR0DRfH/Q7AUCagQFsgAKCRAkR0DRfH/Q7OwhAP9B0lR3HVc+slsyqzSpNWbDQm1NthqqC+FLqBHikFtunQD/RpOcbEoR3dziSTCpRd4RLqhVjFwsdoEigyInVd2qNAU="
+
+[[package]]
+name = "gcc"
+version = "16.1.1+r12+g301eb08fa2c5-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/g/gcc/gcc-16.1.1+r12+g301eb08fa2c5-1-x86_64.pkg.tar.zst"
+sha256 = "80ecc89c7ca567a2c1d460803e1efa434040861f824c34d8fe7000bf27ad82c0"
+signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCafS5tV8UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaCuUiAQCgvoBNp3cS3853nVXfsTs+d/es9OS4BeQYBmVGWL6r0AEAlA6Udb4ZVS6Bhrn9tDrQRVWgGw/cqRgWi4boE2D3rAA="
+
+[[package]]
+name = "libedit"
+version = "20251016_3.1-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/l/libedit/libedit-20251016_3.1-1-x86_64.pkg.tar.zst"
+sha256 = "62fd156cc247c3feb8a750efdfbf5842d9a7c07327890339d4342095d6c86f51"
+signature = "iQIzBAABCgAdFiEEtZcfLFwQqaCMYAMPeGxj8zDXy5IFAmmnYnMACgkQeGxj8zDXy5IRKw/+M9+I0lNV6GAHsqFT85ZxcO1HhZux3sdo1/PZsT81Tana8kud9jHGjDfS7zOItz6a0pJ7Q/7CL5BKUd7T6TKLjhFeuiZeBfREiiHqXoXnFopZZzEiXGLu0qDjS1Q8jPfs3BydLIa7niUx6uCjDBegULZkJgyEg+zeUc60tzywrb8/Ii6/MKazq7dmMVU6F+ZQH4Nv/jovsnT6RWS0YexKF0qMZzDRaUCZs7pHkllQJCWPa2O3OdUEhTopKxqWn5UeeMmdeIyyqy7cBhGKmQbbK7wxhQkIpK3Q2By7fLldeXOsrqD64xHXL7dupuXqI+6U/uO8KsNhbJRY2JRI2nUsqDwM8qxoR9OTpjJuBbFX6PzpgluB9c0WD/ISO60o/bcd4iXdkfCb66Tk+Oav6dr5tRVj7ifFzrmmV4Av6UMwtajKiebckOc4WXmgAd4Rd8uMAecFS+Mz7ZIKwaJkFRHGa7L57FpLAh0ox58cILYdqXJdUcwT4vTQvKEXO3ZIvcKmQBc8PhD/iSjEln5KcQy/2B3+e2n3gsVbggykMYHhFY6ae1x2b5Knt17NqCLTj/ITbgAdsrBFikkRCUKHMKthz8YcSYL/tUkrSd0AmxVMteSZUO19bqj0ZTwrU2eI2zqPon4j2rhAEEpohfpfvPDoOvronFeObj0S+nF4IGbmzp8="
+
+[[package]]
+name = "libgit2"
+version = "1:1.9.3-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/l/libgit2/libgit2-1:1.9.3-1-x86_64.pkg.tar.zst"
+sha256 = "676caaf7c963aedc46db0a3475064344d9eea74fe0d8429c6c6aa438b5d00a7e"
+signature = "iHUEABYKAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCafl5IgAKCRBtQr3RFuAGj5YOAP460nYsYISWcglMsp+ZuvB1buTRmP3N2GpNDO88QKnhLQD/WONQLtk1BqMrG09NepuDz4/3AVnri64jDURi+t6i7Q0="
+
+[[package]]
+name = "libisl"
+version = "0.27-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/l/libisl/libisl-0.27-1-x86_64.pkg.tar.zst"
+sha256 = "55a36e8195e6d9ce2efeb4276c60df6b6e7d94812fa36f8423d5ce664a5d34df"
+signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCZtWJeV8UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaCgPbAP9GNpnE0ra4qZOGYyJtfnyG42f8Z9dLpX21F/sY/a2UCgD/dz8x7harwjTofWctVHyyCacJsLhSq2jvSfrvvL4H/w8="
+
+[[package]]
+name = "libmpc"
+version = "1.4.1-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/l/libmpc/libmpc-1.4.1-1-x86_64.pkg.tar.zst"
+sha256 = "880bdba957ebe5136449c7b61821e92628d7bdd43f370e5a0818d229372d3851"
+signature = "iQEzBAABCgAdFiEEFRnVq6Zb9vwrc8dWek52CV2KUuQFAmnhAlsACgkQek52CV2KUuSBcgf9E61NpAV+F+wHPlOgZOT9yurZAhQwUNd4SRQkNEFrbyMJ1C3Bu9vUayr05Q+MxeQ8/J0W5aACrWSOEAtvYlu9vfmzbn7/S9rHtH9fmvmj46hZemo48cVTq9YTQA1Doe5e9j3DTOWdEsWv7XCMSIXGI2RdIXYB+TH1DLNi7B95EwDySH7SpznjH+SGv9ttVMsmAChRbGR3fIVi6hz6OgSGErFJJmTI5jwt06U6L7Yhl/4ybvYXuh1DGhdFpNhJBGLcYmQhBhv3OGa2dwj051fEjneL2PK80u4nmc+3dP7cOW3pY8jBDpOVfRvnAwiY/NuJMK1YK3iFd3YbYQnuu1D2cQ=="
+
+[[package]]
+name = "lld"
+version = "22.1.5-3"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/l/lld/lld-22.1.5-3-x86_64.pkg.tar.zst"
+sha256 = "63ee376649e81e82896557965aea3b580cfc586bb0aff9ea7e1323df60b79b62"
+signature = "iHUEABYKAB0WIQTS6V/sAVzx+RGqqww9TFAIu1yNKQUCaf8l5wAKCRA9TFAIu1yNKZIZAP9x47L46/b1+pD/kAX3GSy4S6AKKFeOMzPkmCNiuIv6cQD9GUHaZjFuVBcQOYu6LcoQpD9ZxRXz+yvYN7mYxwDwvw8="
+
+[[package]]
+name = "llhttp"
+version = "9.3.1-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/l/llhttp/llhttp-9.3.1-1-x86_64.pkg.tar.zst"
+sha256 = "e93332a577aacebdef11d0626df9a4f45dd6468187309693ccaa8de1547dc71c"
+signature = "iQIzBAABCgAdFiEEsNZSlUdmBrcfDG+CqF6BHrTKLggFAmmQzoAACgkQqF6BHrTKLgjUNw/+KlDsMf3ITF8QKgoEMWg57td+bZVbLijaRgOWlbJozcO76Ri8mOhCOv+mIpT/H44upsBeCHkooYi1YmV48m7vLbtBPcqKpr5d1+ccfh3BTzPZXZacw5jUASifAD84M2w4g2GrvrfUn4lFvy8WAYWUmYLEKdMIXVR9abV0M+B8yrNxgeyPzbHHlleJ9tGHHVuTV99GbRsA5HktkrknfoLKZnzMt+jk1uqhqLAPZaSJ41oFwhRyEkCXqOUb2kEqlSJo6Y94n/ipy50pk04RjiB5D75VTm/lJHPBFOIH/bA20K/G15EBH7ql7D9M/tFWaBWaErlTSKf/hT+x8NIf913dcnCxzDBwinMUnrsiJJyp4gSa+dRKgu6BOuF5z35neZVLYHNtyhQmWGzMc0J6w0mhLFqglhEFen+G9NMTfhu9agvxHAZKgA3hnZEsBs09F6XvgZN5jA23pNUKL+lw0hBd6zgPM5yILHVXsBPgGuwr7NjvfBKx10z/uHRz+Jtvm0r5KSTlq4pwz1sWNoSwKQN/2Hb8YdEw1DLoxYXSpDcDtPhUGqZz4wExfFoC+Qo2M1hp7zRTRrRkwf9S8Lnx7IxEX9Qv0miqoJTEkB0TnIsLlg2sT9AISOMHbB6eMyPLscS/PYB3QzJ4uv5RMQx1zJ7GuY7XahJGYY0moYFfcrWFoSw="
+
+[[package]]
+name = "llvm-libs"
+version = "22.1.5-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/l/llvm-libs/llvm-libs-22.1.5-1-x86_64.pkg.tar.zst"
+sha256 = "4694118dbf5704a482c82bd0ea292f891068ef36935f897bea73743187bc3482"
+signature = "iHUEABYKAB0WIQTS6V/sAVzx+RGqqww9TFAIu1yNKQUCafy4/AAKCRA9TFAIu1yNKdU1AP9hn3ew7dYYkgFxQ6Q6rgETUJuASDqZmiBdG4kQMamFXAEA5dNjMQIMAAzyugJHR0bMzNjJeJ4kz3jN4mG43qcttww="
+
+[[package]]
+name = "musl"
+version = "1.2.6-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/m/musl/musl-1.2.6-1-x86_64.pkg.tar.zst"
+sha256 = "193b040c7174637ebcb7449914017e4b300089884a659d00bce59888744dc184"
+signature = "iQJLBAABCgA1FiEEiee5MxxK59f699MFwTIpOVS75K0FAmm/In4XHHNwdXB5a2luQGFyY2hsaW51eC5vcmcACgkQwTIpOVS75K11JBAAtrp8Ovvj6VJOhuR/QKfUDDCpWbcvh+wyqSwXIgRGBR3+m5+HcHkaTUGxtodWpCjiEJeM303SGTgPVsSKlUpNzK/emqhRpKX6pETNvFCjGYZGplvBhdh/LNRf/OMzU2Ld16woc4RUYKciV1LDohB1XVMHpG//QkTHcLOJT4G57NJoS9t0JumxPdZUwEbVrYG56wEMIIVABfY2zb2iFCrjkr1N8GlTCnI8HXpsq0E4yMkhIZ/a1dkFEDmWgFX8g+7JaVVbMFGDaJMGBIM/9bI7Ydc9JtXFbC6aRizF86ZfZdlK3xj0/WAFaqDoj1/O3aToaTqYic/qgPeOqo/nBOyyMxPU9dpz3RBOD9poSiLhjvhERyMSGwuGeAt8D2EGsrUjhJvydF84WfF0ZhlIZIWh1pW+Rf/CPzMeeM3eipLv58HTj5v70JSJuinTM0oIHWoIhsyZPz39dW0UJ+Qqi455f8h8Nj3a/UZfwElNqwLFkV4Qjt9qSRy8twaBNlQuh04PpRhSktRiXNKqc4Ldvcuo/9rhxdByORyfaelYL7OvyX5DyZqmlr1MmtREu4mHU2wN0znRfGinGdVNcqFtFScaABM2tnG8ZE1fOngHg6+P7cFzYYNN8PRaNUHGmSEmbHOoC3k236GmWbCTbDfcZcLauORmJg5GxxoW64PO53CdBRs="
+
+[[package]]
+name = "rust"
+version = "1:1.95.0-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/r/rust/rust-1:1.95.0-1-x86_64.pkg.tar.zst"
+provides = ["cargo"]
+sha256 = "7fb944fe7316c4b56946e97629c1c274c7dd477301f72ff38665e516a961cf61"
+signature = "iHUEABYKAB0WIQSDvIiJNRtd67toQW64rAhgDxCM3wUCaeD+JwAKCRC4rAhgDxCM3+a+AQDYqAJgf84M0ML7M7irZpz+lqnDUPOWdv1f2Ncndw5ilQD/Y5IQ3hhescVkc3Qq957lfwEtFF4JHwVgHDUYSb7NXgM="
+
+[[package]]
+name = "rust-musl"
+version = "1:1.95.0-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/r/rust-musl/rust-musl-1:1.95.0-1-x86_64.pkg.tar.zst"
+sha256 = "362af945af3da46608036f094f73124694d816001810872d728a34fe8af5f683"
+signature = "iHUEABYKAB0WIQSDvIiJNRtd67toQW64rAhgDxCM3wUCaeD+KQAKCRC4rAhgDxCM39dFAP4jpCK0BwjQlfA9DIICUNe81RSMq3dC1LwoGny1v6pYggD8CmDX4Y2TizyqFq53J6i+lTe1jhW6qjtDTxw/MSpO9wQ="

--- a/repro-env.toml
+++ b/repro-env.toml
@@ -1,0 +1,6 @@
+[container]
+image = "docker.io/archlinux/archlinux:repro"
+
+[packages]
+system = "archlinux"
+dependencies = ["cargo", "musl", "rust-musl"]

--- a/scripts/mkrelease.sh
+++ b/scripts/mkrelease.sh
@@ -46,7 +46,9 @@ sed -i "s/version = \"${sed_pattern#v}\"/version = \"${release_tag}\"/g" Cargo.t
 sed -i "s/${sed_pattern#v}/${release_tag}/g" doc/man/oniri.1.scd
 
 # Build binary
-rm -rf target/ && cargo build --release
+repro-env update
+rm -rf target/ && repro-env build -- cargo build --release --target x86_64-unknown-linux-musl
+podman image prune -af
 
 # Update changelog
 git-cliff -up CHANGELOG.md
@@ -88,20 +90,20 @@ sha256sum "oniri-${release_tag}.tar.gz" > "oniri-${release_tag}.tar.gz.sha256"
 gpg --local-user D33FAA16B937F3B2 --armor --detach-sign "oniri-${release_tag}.tar.gz.sha256"
 
 # Sign binary and checksum
-mv target/release/oniri "target/release/oniri-${release_tag}-amd64"
-gpg --local-user D33FAA16B937F3B2 --armor --detach-sign "target/release/oniri-${release_tag}-amd64"
-sha256sum "target/release/oniri-${release_tag}-amd64" > "target/release/oniri-${release_tag}-amd64.sha256"
-gpg --local-user D33FAA16B937F3B2 --armor --detach-sign "target/release/oniri-${release_tag}-amd64.sha256"
+mv target/x86_64-unknown-linux-musl/release/oniri "target/x86_64-unknown-linux-musl/release/oniri-${release_tag}-amd64"
+gpg --local-user D33FAA16B937F3B2 --armor --detach-sign "target/x86_64-unknown-linux-musl/release/oniri-${release_tag}-amd64"
+sha256sum "target/x86_64-unknown-linux-musl/release/oniri-${release_tag}-amd64" > "target/x86_64-unknown-linux-musl/release/oniri-${release_tag}-amd64.sha256"
+gpg --local-user D33FAA16B937F3B2 --armor --detach-sign "target/x86_64-unknown-linux-musl/release/oniri-${release_tag}-amd64.sha256"
 
 # Upload assets
 gh release upload "v${release_tag}" \
 	"oniri-${release_tag}.tar.gz.asc" \
 	"oniri-${release_tag}.tar.gz.sha256" \
 	"oniri-${release_tag}.tar.gz.sha256.asc" \
-	"target/release/oniri-${release_tag}-amd64" \
-	"target/release/oniri-${release_tag}-amd64.asc" \
-	"target/release/oniri-${release_tag}-amd64.sha256" \
-	"target/release/oniri-${release_tag}-amd64.sha256.asc"
+	"target/x86_64-unknown-linux-musl/release/oniri-${release_tag}-amd64" \
+	"target/x86_64-unknown-linux-musl/release/oniri-${release_tag}-amd64.asc" \
+	"target/x86_64-unknown-linux-musl/release/oniri-${release_tag}-amd64.sha256" \
+	"target/x86_64-unknown-linux-musl/release/oniri-${release_tag}-amd64.sha256.asc"
 
 # Cleanup
 rm -rf "oniri-${release_tag}.tar.gz"* target/


### PR DESCRIPTION
### Description

Use [repro-env](https://github.com/kpcyrd/repro-env) to build release binary, in order to provide a reproducible build environment and an easy way to reproduce the binary.

Release binary are also now statically build against `musl` for a lighter and more portable binary.
