### PR TITLE
chore(renovate): Relax lockFileMaintenance schedule

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,7 +2,7 @@
   "dependencyDashboard": false,
   "assignees": ["Antiz96"],
   "git-submodules": { "enabled": true },
-  "lockFileMaintenance": { "enabled": true, "schedule": ["at any time"] },
+  "lockFileMaintenance": { "enabled": true },
   "commitMessagePrefix": "chore(deps): ",
   "commitMessageAction": "update",
   "commitMessageTopic": "{{depName}}",


### PR DESCRIPTION
<!-- Please, read the contributing guidelines before opening a pull request: https://github.com/Antiz96/arch-update/blob/main/CONTRIBUTING.md -->

### Description

After a second thought, the default weekly schedule is enough here.

It also generates noisy warnings in renovate webUI when there's no change to push