### PR TITLE
chore(release): Switch repro-env image to the default archlinux tag

### DIFF
--- a/repro-env.toml
+++ b/repro-env.toml
@@ -1,5 +1,5 @@
 [container]
-image = "docker.io/archlinux/archlinux:repro"
+image = "docker.io/archlinux/archlinux"
 
 [packages]
 system = "archlinux"


### PR DESCRIPTION
### Description

Switch the repro-env image to the default archlinux tag (`base`). Using the `repro` tag requires https://github.com/kpcyrd/repro-env/pull/52 to be merged and released in order to be able to initialize the pacman keyring as an init step. We'll switch back to the `repro` tag once possible.