### PR TITLE
fix: re-fullscreen window moved by mouse drag

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -112,10 +112,6 @@ fn main() -> anyhow::Result<()> {
                     .iter()
                     .find_map(|(&tracked_ws, windows)| windows.contains(&id).then_some(tracked_ws));
 
-                if previous_ws == Some(ws) {
-                    continue;
-                }
-
                 // Update the workspace/window(s) map
                 for windows in workspace_windows.values_mut() {
                     windows.retain(|&wid| wid != id);


### PR DESCRIPTION
When a window is moved with Mod+LMB, it un-fullscreens. Dropping it back into the same workspace now correctly re-fullscreens it if it's the only window there.

Note that this also applies in first-only mode, regardless of the previous fullscreen state of the window. I think that's reasonable since the same thing would happen if it was moved to another empty workspace, but I wanted to mention it anyway.

Implementation-wise I could have added an extra check for this but I think just removing the early return is cleaner. I don't think this has any side effects but you might want to double check.