### PR TITLE
style(help): Remove extra spaces

### DIFF
--- a/src/help.rs
+++ b/src/help.rs
@@ -15,7 +15,7 @@ pub fn show_help() {
     println!(
         "  -T, --tiling-layout     Unmaximize the first window when opening a second one, like in a tiling compositor"
     );
-    println!("  -E, --edges-maximizing     Maximize windows to edges");
+    println!("  -E, --edges-maximizing  Maximize windows to edges");
     println!(
         "  -H, --height-tolerance  Set the height size tolerance (in pixels) when comparing the window size to the output size to determine if the window is maximized or not" // https://github.com/Antiz96/oniri/issues/3
     );


### PR DESCRIPTION
### Description

Remove extra / useless spaces in help message

### Screenshots

Before:

<img width="1091" height="342" alt="image" src="https://github.com/user-attachments/assets/22490849-8d2a-47d6-aeaf-8c0440f51678" />

After:

<img width="1091" height="342" alt="image" src="https://github.com/user-attachments/assets/e5f6e6a1-d8dc-44ae-a8bf-ea4e74bafd24" />
