### PR TITLE
fix: Use a lockfile to prevent multiple executions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,6 +106,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
 name = "clap"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -190,6 +196,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys",
+]
+
+[[package]]
 name = "env_filter"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -219,6 +246,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -271,6 +319,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libredox"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "log"
 version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -320,11 +377,19 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "clap",
+ "dirs",
  "env_logger",
+ "fs2",
  "log",
  "niri-ipc",
  "predicates",
 ]
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "portable-atomic"
@@ -409,6 +474,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom",
+ "libredox",
+ "thiserror",
 ]
 
 [[package]]
@@ -546,6 +622,34 @@ checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,9 @@ license = "GPL-3.0-or-later"
 [dependencies]
 anyhow = "1.0.102"
 clap = { version = "4.6.1", features = ["derive"] }
+dirs = "6.0.0"
 env_logger = "0.11.9"
+fs2 = "0.4.3"
 log = "0.4.29"
 niri-ipc = "26.0.0"
 

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -1,0 +1,39 @@
+//! Create (if needed) and acquire lockfile
+//! in order to prevent multiple instances to run at the same time
+
+use fs2::FileExt;
+use std::fs::{self, File, OpenOptions};
+
+pub fn acquire_lockfile() -> std::io::Result<File> {
+    // Create oniri cachedir (if it doesn't exist)
+    let cachedir = dirs::cache_dir()
+        .ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                "could not determine cache directory",
+            )
+        })?
+        .join("oniri");
+    fs::create_dir_all(&cachedir)?;
+
+    let lockfile_path = cachedir.join("oniri.lock");
+
+    let lockfile = OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(false)
+        .open(lockfile_path)?;
+
+    lockfile.try_lock_exclusive().map_err(|err| {
+        if err.kind() == std::io::ErrorKind::WouldBlock {
+            std::io::Error::new(
+                std::io::ErrorKind::AlreadyExists,
+                "oniri is already running",
+            )
+        } else {
+            err
+        }
+    })?;
+
+    Ok(lockfile)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ use niri_ipc::{Event, state::EventStreamState, state::EventStreamStatePart};
 use crate::{maximize_window::maximize_window, size_compare::is_maximized};
 
 mod help;
+mod lockfile;
 mod maximize_window;
 mod outputs_map; // https://github.com/Antiz96/oniri/issues/3
 mod size_compare; // https://github.com/Antiz96/oniri/issues/3
@@ -63,6 +64,23 @@ fn main() -> anyhow::Result<()> {
         version::show_version();
         return Ok(());
     }
+
+    // Create (if needed) and acquire lock file
+    // Exit if there's already an instance running
+    // or if there was an issue creating or acquiring the lockfile (e.g. permission issue)
+    let _lock = match lockfile::acquire_lockfile() {
+        Ok(lockfile) => lockfile,
+
+        Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => {
+            eprintln!("Another instance of oniri is already running");
+            std::process::exit(1);
+        }
+
+        Err(err) => {
+            eprintln!("Failed to acquire lockfile:\n{err}");
+            std::process::exit(1);
+        }
+    };
 
     // Run in "first-only" mode if the -F / --first-only arg is passed
     let first_only = args.first_only;


### PR DESCRIPTION
### Description

Use a lockfile mechanism to prevent multiple instances of oniri from running at the same time.

The lockfile is created with the 'cache_dir()' function (which automatically expands to $XDG_CACHE_HOME or $HOME/.cache), so `{$XDG_CACHE_HOME:-$HOME}/oniri/oniri.lock`.