### PR TITLE
chore: Use error log and exit prematurely on socket connection error

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@
 //! and maximize it if so.
 
 use clap::Parser;
-use log::{debug, info};
+use log::{debug, error, info};
 use niri_ipc::{Event, state::EventStreamState, state::EventStreamStatePart};
 use std::collections::HashMap;
 use std::io::ErrorKind;
@@ -74,9 +74,9 @@ fn main() -> anyhow::Result<()> {
     // or if there was an issue creating or acquiring the lockfile (e.g. permission issue)
     let _lock = lockfile::acquire_lockfile().unwrap_or_else(|error| {
         if error.kind() == ErrorKind::AlreadyExists {
-            eprintln!("Another instance of oniri is already running");
+            error!("Another instance of oniri is already running");
         } else {
-            eprintln!("Failed to acquire lockfile:\n{error}");
+            error!("Failed to acquire lockfile:\n{error}");
         }
 
         process::exit(1);

--- a/src/socket_connections.rs
+++ b/src/socket_connections.rs
@@ -2,26 +2,27 @@
 
 use log::error;
 use niri_ipc::{Request, Response, socket::Socket};
+use std::process;
 
 pub fn init_socket_connections() -> anyhow::Result<(Socket, Socket)> {
     // Connect to niri IPC socket
-    let mut event_socket = Socket::connect().map_err(|error| {
-        error!("Failed to connect to niri IPC socket: {}", error);
-        error
-    })?;
+    let mut event_socket = Socket::connect().unwrap_or_else(|error| {
+        error!("Failed to connect to niri IPC socket:\n{}", error);
+        process::exit(2);
+    });
 
     // Start the event stream
     let reply = event_socket.send(Request::EventStream)?;
     if !matches!(reply, Ok(Response::Handled)) {
-        error!("Failed to start event stream: {:?}", reply);
+        error!("Failed to start event stream:\n{:?}", reply);
         return Err(anyhow::anyhow!(""));
     }
 
     // Create a separate socket connection to send actions
-    let action_socket = Socket::connect().map_err(|error| {
-        error!("Failed to connect to niri IPC socket: {}", error);
-        error
-    })?;
+    let action_socket = Socket::connect().unwrap_or_else(|error| {
+        error!("Failed to connect to niri IPC socket:\n{}", error);
+        process::exit(2);
+    });
 
     // Return both sockets connections so they can be called elsewhere
     Ok((event_socket, action_socket))


### PR DESCRIPTION
### Description

Generalize the usage of logger and exit prematurely on socket connection error (allows to avoid duplicated error entry and have a specific exit code)

