### PR TITLE
chore: Use more modern variable calling method

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -106,7 +106,7 @@ fn main() -> anyhow::Result<()> {
     // This can be dropped once https://github.com/Antiz96/oniri/issues/3 is resolved
     let tol_h = args.height_tolerance;
     let tol_w = args.width_tolerance;
-    info!("Using tolerances: height={}, width={}", tol_h, tol_w);
+    info!("Using tolerances: height={tol_h}, width={tol_w}");
 
     // Initialize connections to niri IPC socket, start the event stream and gather events
     let (event_socket, mut action_socket) = socket_connections::init_socket_connections()?;

--- a/src/maximize_window.rs
+++ b/src/maximize_window.rs
@@ -14,7 +14,7 @@ pub fn maximize_window(
         let _ = socket.send(Request::Action(Action::MaximizeWindowToEdges {
             id: Some(window_id),
         }));
-        info!("Maximized window to edges {}", window_id);
+        info!("Maximized window to edges {window_id}");
     } else {
         // We need this information to restore focus state after maximizing @window_id
         let Some(focused_id) = state
@@ -29,7 +29,7 @@ pub fn maximize_window(
         let _ = socket.send(Request::Action(Action::FocusWindow { id: window_id }));
         let _ = socket.send(Request::Action(Action::MaximizeColumn {}));
         let _ = socket.send(Request::Action(Action::FocusWindow { id: focused_id }));
-        info!("Maximized window {}", window_id);
+        info!("Maximized window {window_id}");
     }
     Ok(())
 }

--- a/src/outputs_map.rs
+++ b/src/outputs_map.rs
@@ -15,7 +15,7 @@ pub fn init_outputs_map(action_socket: &mut Socket) -> anyhow::Result<HashMap<St
     };
 
     for name in outputs.keys() {
-        info!("Registered output: {}", name);
+        info!("Registered output: {name}");
     }
 
     Ok(outputs)

--- a/src/size_compare.rs
+++ b/src/size_compare.rs
@@ -18,13 +18,13 @@ pub fn is_maximized(
     let window = match state.windows.windows.get(&window_id) {
         Some(w) => w,
         None => {
-            warn!("Window {} not found in state", window_id);
+            warn!("Window {window_id} not found in state");
             return false;
         }
     };
 
     if window.is_floating {
-        info!("Window {} is floating, skipping", window_id);
+        info!("Window {window_id} is floating, skipping");
         return false;
     }
 
@@ -34,7 +34,7 @@ pub fn is_maximized(
     {
         Some(ws) => ws,
         None => {
-            warn!("Workspace for window {} not found", window_id);
+            warn!("Workspace for window {window_id} not found");
             return false;
         }
     };
@@ -62,18 +62,14 @@ pub fn is_maximized(
     let tile_h = tile_h as i32;
 
     debug!(
-        "Window {}: out_w={}, out_h={}, tile_w={}, tile_h={}, tol_w={}, tol_h={}",
-        window_id, out_w, out_h, tile_w, tile_h, tol_w, tol_h
+        "Window {window_id}: out_w={out_w}, out_h={out_h}, tile_w={tile_w}, tile_h={tile_h}, tol_w={tol_w}, tol_h={tol_h}"
     );
 
     let width_ok = (out_w - tile_w).abs() <= tol_w;
     let height_ok = (out_h - tile_h).abs() <= tol_h;
 
     debug!(
-        "Window {}: width_ok={}, height_ok={}, maximized={}",
-        window_id,
-        width_ok,
-        height_ok,
+        "Window {window_id}: width_ok={width_ok}, height_ok={height_ok}, maximized={}",
         width_ok && height_ok
     );
 

--- a/src/socket_connections.rs
+++ b/src/socket_connections.rs
@@ -7,7 +7,7 @@ use std::process;
 pub fn init_socket_connections() -> anyhow::Result<(Socket, Socket)> {
     // Connect to niri IPC socket
     let mut event_socket = Socket::connect().unwrap_or_else(|error| {
-        error!("Failed to connect to niri IPC socket:\n{}", error);
+        error!("Failed to connect to niri IPC socket:\n{error}");
         process::exit(2);
     });
 
@@ -20,7 +20,7 @@ pub fn init_socket_connections() -> anyhow::Result<(Socket, Socket)> {
 
     // Create a separate socket connection to send actions
     let action_socket = Socket::connect().unwrap_or_else(|error| {
-        error!("Failed to connect to niri IPC socket:\n{}", error);
+        error!("Failed to connect to niri IPC socket:\n{error}");
         process::exit(2);
     });
 


### PR DESCRIPTION
### Description

Since Rust 1.58.0 (which was released in Jan. 13, 2022), you can directly put variable names inside the placeholders.

This is the way used in 'The Book' and it's arguably easier to read and write.