### PR TITLE
feat: add `-R / --reclaim-space` to reclaim empty screen space left by closed windows

### DIFF
--- a/doc/man/oniri.1.scd
+++ b/doc/man/oniri.1.scd
@@ -23,8 +23,8 @@ Oniri is a tool that automatically maximizes the *on*ly window of a *niri* works
 *-E, --edges-maximizing*
 	Maximize windows to edges.
 
-*-S, --fill-screen-space*
-	Fill empty screen space left by closed windows.
+*-R, --reclaim-space*
+	Reclaim empty screen space left by closed windows.
 
 *-H, --height-tolerance* <number>
 	Set the height size tolerance (in pixels) when comparing the window size to the output size to determine if the window is maximized or not (https://github.com/Antiz96/oniri/issues/3).

--- a/doc/man/oniri.1.scd
+++ b/doc/man/oniri.1.scd
@@ -23,6 +23,9 @@ Oniri is a tool that automatically maximizes the *on*ly window of a *niri* works
 *-E, --edges-maximizing*
 	Maximize windows to edges.
 
+*-S, --fill-screen-space*
+	Fill empty screen space left by closed windows.
+
 *-H, --height-tolerance* <number>
 	Set the height size tolerance (in pixels) when comparing the window size to the output size to determine if the window is maximized or not (https://github.com/Antiz96/oniri/issues/3).
 	Defaults to 150.

--- a/res/completions/oniri.bash
+++ b/res/completions/oniri.bash
@@ -4,7 +4,7 @@ _oniri() {
 	opts=('-F --first-only
 	       -T --tiling-layout
 	       -E --edges-maximizing
-	       -S --fill-screen-space
+	       -R --reclaim-space
 	       -H --height-tolerance
 	       -W --width-tolerance
 	       -h --help

--- a/res/completions/oniri.bash
+++ b/res/completions/oniri.bash
@@ -4,6 +4,7 @@ _oniri() {
 	opts=('-F --first-only
 	       -T --tiling-layout
 	       -E --edges-maximizing
+	       -S --fill-screen-space
 	       -H --height-tolerance
 	       -W --width-tolerance
 	       -h --help

--- a/res/completions/oniri.fish
+++ b/res/completions/oniri.fish
@@ -3,7 +3,7 @@ complete -c oniri -f
 complete -c oniri -s F -l first-only -d 'Only maximize the first window opened, do no act on the last remaining one'
 complete -c oniri -s T -l tiling-layout -d 'Unmaximize the first window when opening a second one, like in a tiling compositor'
 complete -c oniri -s E -l edges-maximizing -d 'Maximize windows to edges'
-complete -c oniri -s S -l fill-screen-space -d 'Fill empty screen space left by closed windows'
+complete -c oniri -s R -l reclaim-space -d 'Reclaim empty screen space left by closed windows'
 complete -c oniri -s H -l height-tolerance -d 'Set the height size tolerance (in pixels) when comparing the window size to the output size to determine if the window is maximized or not'
 complete -c oniri -s W -l width-tolerance -d 'Set the width size tolerance (in pixels) when comparing the window size to the output size to determine if the window is maximized or not'
 complete -c oniri -s h -l help -d 'Display the help message'

--- a/res/completions/oniri.fish
+++ b/res/completions/oniri.fish
@@ -3,6 +3,7 @@ complete -c oniri -f
 complete -c oniri -s F -l first-only -d 'Only maximize the first window opened, do no act on the last remaining one'
 complete -c oniri -s T -l tiling-layout -d 'Unmaximize the first window when opening a second one, like in a tiling compositor'
 complete -c oniri -s E -l edges-maximizing -d 'Maximize windows to edges'
+complete -c oniri -s S -l fill-screen-space -d 'Fill empty screen space left by closed windows'
 complete -c oniri -s H -l height-tolerance -d 'Set the height size tolerance (in pixels) when comparing the window size to the output size to determine if the window is maximized or not'
 complete -c oniri -s W -l width-tolerance -d 'Set the width size tolerance (in pixels) when comparing the window size to the output size to determine if the window is maximized or not'
 complete -c oniri -s h -l help -d 'Display the help message'

--- a/res/completions/oniri.zsh
+++ b/res/completions/oniri.zsh
@@ -5,6 +5,7 @@ opts=(
     {-F,--first-only}'[Only maximize the first window opened, do no act on the last remaining one]'
     {-T,--tiling-layout}'[Unmaximize the first window when opening a second one, like in a tiling compositor]'
     {-E,--edges-maximizing}'[Maximize windows to edges]'
+    {-S,--fill-screen-space}'[Fill empty screen space left by closed windows]'
     {-H,--height-tolerance}'[Set the height size tolerance (in pixels) when comparing the window size to the output size to determine if the window is maximized or not (defaults to 150)]'
     {-W,--width-tolerance}'[Set the width size tolerance (in pixels) when comparing the window size to the output size to determine if the window is maximized or not (defaults to 150)]'
     {-h,--help}'[Display the help message]'

--- a/res/completions/oniri.zsh
+++ b/res/completions/oniri.zsh
@@ -5,7 +5,7 @@ opts=(
     {-F,--first-only}'[Only maximize the first window opened, do no act on the last remaining one]'
     {-T,--tiling-layout}'[Unmaximize the first window when opening a second one, like in a tiling compositor]'
     {-E,--edges-maximizing}'[Maximize windows to edges]'
-    {-S,--fill-screen-space}'[Fill empty screen space left by closed windows]'
+    {-R,--reclaim-space}'[Reclaim empty screen space left by closed windows]'
     {-H,--height-tolerance}'[Set the height size tolerance (in pixels) when comparing the window size to the output size to determine if the window is maximized or not (defaults to 150)]'
     {-W,--width-tolerance}'[Set the width size tolerance (in pixels) when comparing the window size to the output size to determine if the window is maximized or not (defaults to 150)]'
     {-h,--help}'[Display the help message]'

--- a/src/fill_gap.rs
+++ b/src/fill_gap.rs
@@ -14,16 +14,15 @@ pub fn is_leftmost_column(state: &EventStreamState, window_id: u64) -> bool {
 
 pub fn fill_gap(
     socket: &mut Socket,
-    move_on_close: bool,
-    was_leftmost: bool,
     remaining_windows: usize,
 ) -> anyhow::Result<()> {
-    if !move_on_close || was_leftmost || remaining_windows <= 1 {
+    if remaining_windows <= 1 {
         return Ok(());
     }
 
     let _ = socket.send(Request::Action(Action::FocusColumnLeft {}));
     let _ = socket.send(Request::Action(Action::FocusColumnRight {}));
+
     info!("Nudged focus to fill gap left by closed window");
 
     Ok(())

--- a/src/fill_gap.rs
+++ b/src/fill_gap.rs
@@ -2,14 +2,33 @@
 //! the viewport and eliminate any leftover gap on the edge of the screen.
 
 use log::info;
+use niri_ipc::state::EventStreamState;
 use niri_ipc::{Action, Request, socket::Socket};
+
+pub fn is_leftmost_column(state: &EventStreamState, window_id: u64) -> bool {
+    let Some(window) = state.windows.windows.get(&window_id) else {
+        return false;
+    };
+    let Some((column, _)) = window.layout.pos_in_scrolling_layout else {
+        return false;
+    };
+
+    state
+        .windows
+        .windows
+        .values()
+        .filter(|other| other.workspace_id == window.workspace_id)
+        .filter_map(|other| other.layout.pos_in_scrolling_layout)
+        .all(|(other_column, _)| other_column >= column)
+}
 
 pub fn fill_gap(
     socket: &mut Socket,
     move_on_close: bool,
+    was_leftmost: bool,
     remaining_windows: usize,
 ) -> anyhow::Result<()> {
-    if !move_on_close || remaining_windows <= 1 {
+    if !move_on_close || was_leftmost || remaining_windows <= 1 {
         return Ok(());
     }
 

--- a/src/fill_gap.rs
+++ b/src/fill_gap.rs
@@ -1,0 +1,21 @@
+//! Nudge focus left/right after a window closes, forcing niri to rescroll
+//! the viewport and eliminate any leftover gap on the edge of the screen.
+
+use log::info;
+use niri_ipc::{Action, Request, socket::Socket};
+
+pub fn fill_gap(
+    socket: &mut Socket,
+    move_on_close: bool,
+    remaining_windows: usize,
+) -> anyhow::Result<()> {
+    if !move_on_close || remaining_windows <= 1 {
+        return Ok(());
+    }
+
+    let _ = socket.send(Request::Action(Action::FocusColumnLeft {}));
+    let _ = socket.send(Request::Action(Action::FocusColumnRight {}));
+    info!("Nudged focus to fill gap left by closed window");
+
+    Ok(())
+}

--- a/src/fill_gap.rs
+++ b/src/fill_gap.rs
@@ -6,20 +6,10 @@ use niri_ipc::state::EventStreamState;
 use niri_ipc::{Action, Request, socket::Socket};
 
 pub fn is_leftmost_column(state: &EventStreamState, window_id: u64) -> bool {
-    let Some(window) = state.windows.windows.get(&window_id) else {
-        return false;
-    };
-    let Some((column, _)) = window.layout.pos_in_scrolling_layout else {
-        return false;
-    };
+    let window = state.windows.windows.get(&window_id).expect("Window ID not found in state");
+    let (column, _) = window.layout.pos_in_scrolling_layout.expect("Window has no position in scrolling layout");
 
-    state
-        .windows
-        .windows
-        .values()
-        .filter(|other| other.workspace_id == window.workspace_id)
-        .filter_map(|other| other.layout.pos_in_scrolling_layout)
-        .all(|(other_column, _)| other_column >= column)
+    column == 1
 }
 
 pub fn fill_gap(

--- a/src/fill_gap.rs
+++ b/src/fill_gap.rs
@@ -5,17 +5,21 @@ use log::info;
 use niri_ipc::state::EventStreamState;
 use niri_ipc::{Action, Request, socket::Socket};
 
-pub fn is_leftmost_column(state: &EventStreamState, window_id: u64) -> bool {
-    let window = state.windows.windows.get(&window_id).expect("Window ID not found in state");
-    let (column, _) = window.layout.pos_in_scrolling_layout.expect("Window has no position in scrolling layout");
+pub fn is_leftmost(state: &EventStreamState, window_id: u64) -> bool {
+    let window = state
+        .windows
+        .windows
+        .get(&window_id)
+        .expect("Window ID not found in state");
+    let (column, _) = window
+        .layout
+        .pos_in_scrolling_layout
+        .expect("Window has no position in scrolling layout");
 
     column == 1
 }
 
-pub fn fill_gap(
-    socket: &mut Socket,
-    remaining_windows: usize,
-) -> anyhow::Result<()> {
+pub fn fill_gap(socket: &mut Socket, remaining_windows: usize) -> anyhow::Result<()> {
     if remaining_windows <= 1 {
         return Ok(());
     }

--- a/src/help.rs
+++ b/src/help.rs
@@ -10,21 +10,21 @@ pub fn show_help() {
     println!();
     println!("OPTIONS:");
     println!(
-        "  -F, --first-only        Only maximize the first opened window, do not act on the last remaining one"
+        "  -F, --first-only         Only maximize the first opened window, do not act on the last remaining one"
     );
     println!(
-        "  -T, --tiling-layout     Unmaximize the first window when opening a second one, like in a tiling compositor"
+        "  -T, --tiling-layout      Unmaximize the first window when opening a second one, like in a tiling compositor"
     );
-    println!("  -E, --edges-maximizing  Maximize windows to edges");
-    println!("  -M, --move-on-close     Move viewport on window close to fill remaining gap");
+    println!("  -E, --edges-maximizing   Maximize windows to edges");
+    println!("  -S, --fill-screen-space  Fill empty screen space left by closed windows");
     println!(
-        "  -H, --height-tolerance  Set the height size tolerance (in pixels) when comparing the window size to the output size to determine if the window is maximized or not (defaults to 150)" // https://github.com/Antiz96/oniri/issues/3
+        "  -H, --height-tolerance   Set the height size tolerance (in pixels) when comparing the window size to the output size to determine if the window is maximized or not (defaults to 150)" // https://github.com/Antiz96/oniri/issues/3
     );
     println!(
-        "  -W, --width-tolerance   Set the width size tolerance (in pixels) when comparing the window size to the output size to determine if the window is maximized or not (defaults to 150)" // https://github.com/Antiz96/oniri/issues/3
+        "  -W, --width-tolerance    Set the width size tolerance (in pixels) when comparing the window size to the output size to determine if the window is maximized or not (defaults to 150)" // https://github.com/Antiz96/oniri/issues/3
     );
-    println!("  -h, --help              Display this help message");
-    println!("  -V, --version           Display version information");
+    println!("  -h, --help               Display this help message");
+    println!("  -V, --version            Display version information");
     println!();
     println!("For more information, see the oniri(1) man page.");
 }

--- a/src/help.rs
+++ b/src/help.rs
@@ -16,6 +16,7 @@ pub fn show_help() {
         "  -T, --tiling-layout     Unmaximize the first window when opening a second one, like in a tiling compositor"
     );
     println!("  -E, --edges-maximizing  Maximize windows to edges");
+    println!("  -M, --move-on-close     Move viewport on window close to fill remaining gap");
     println!(
         "  -H, --height-tolerance  Set the height size tolerance (in pixels) when comparing the window size to the output size to determine if the window is maximized or not (defaults to 150)" // https://github.com/Antiz96/oniri/issues/3
     );

--- a/src/help.rs
+++ b/src/help.rs
@@ -10,21 +10,21 @@ pub fn show_help() {
     println!();
     println!("OPTIONS:");
     println!(
-        "  -F, --first-only         Only maximize the first opened window, do not act on the last remaining one"
+        "  -F, --first-only        Only maximize the first opened window, do not act on the last remaining one"
     );
     println!(
-        "  -T, --tiling-layout      Unmaximize the first window when opening a second one, like in a tiling compositor"
+        "  -T, --tiling-layout     Unmaximize the first window when opening a second one, like in a tiling compositor"
     );
-    println!("  -E, --edges-maximizing   Maximize windows to edges");
-    println!("  -S, --fill-screen-space  Fill empty screen space left by closed windows");
+    println!("  -E, --edges-maximizing  Maximize windows to edges");
+    println!("  -R, --reclaim-space     Reclaim empty screen space left by closed windows");
     println!(
-        "  -H, --height-tolerance   Set the height size tolerance (in pixels) when comparing the window size to the output size to determine if the window is maximized or not (defaults to 150)" // https://github.com/Antiz96/oniri/issues/3
+        "  -H, --height-tolerance  Set the height size tolerance (in pixels) when comparing the window size to the output size to determine if the window is maximized or not (defaults to 150)" // https://github.com/Antiz96/oniri/issues/3
     );
     println!(
-        "  -W, --width-tolerance    Set the width size tolerance (in pixels) when comparing the window size to the output size to determine if the window is maximized or not (defaults to 150)" // https://github.com/Antiz96/oniri/issues/3
+        "  -W, --width-tolerance   Set the width size tolerance (in pixels) when comparing the window size to the output size to determine if the window is maximized or not (defaults to 150)" // https://github.com/Antiz96/oniri/issues/3
     );
-    println!("  -h, --help               Display this help message");
-    println!("  -V, --version            Display version information");
+    println!("  -h, --help              Display this help message");
+    println!("  -V, --version           Display version information");
     println!();
     println!("For more information, see the oniri(1) man page.");
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -307,8 +307,8 @@ fn main() -> anyhow::Result<()> {
 
                 // If running in "fill-screen-space" mode, nudge the focus to close any empty space
                 // left by closed windows (if needed)
-                if fill_screen_space && !closed_window_was_leftmost {
-                    nudge_focus(&mut action_socket, windows.len())?;
+                if fill_screen_space && !closed_window_was_leftmost && windows.len() > 1 {
+                    nudge_focus(&mut action_socket)?;
                 }
 
                 // Skip if running in "first only" mode

--- a/src/main.rs
+++ b/src/main.rs
@@ -109,9 +109,7 @@ fn main() -> anyhow::Result<()> {
 
     let move_on_close = args.move_on_close;
     if move_on_close {
-        info!(
-            "Running in move-on-close mode: Moving the viewport on window close to fill remaining gap"
-        );
+        info!("Running in move-on-close mode: Moving the viewport on close to fill remaining gap");
     }
 
     // Set pixel tolerances for window/output size comparison
@@ -143,6 +141,11 @@ fn main() -> anyhow::Result<()> {
 
     // Loop over events
     while let Ok(event) = read_event() {
+        // Check if the closing window sits in the leftmost column, before state.apply()
+        // below removes it from the state and this information becomes unreachable.
+        let closed_window_was_leftmost =
+            matches!(&event, Event::WindowClosed { id } if fill_gap::is_leftmost_column(&state, *id));
+
         // Update state
         // This can be dropped once https://github.com/Antiz96/oniri/issues/3 is resolved
         state.apply(event.clone());
@@ -298,9 +301,15 @@ fn main() -> anyhow::Result<()> {
                 // Update the workspace vector
                 windows.retain(|&wid| wid != id);
 
-                // If the -M / --move-on-close arg is passed, force niri to rescroll
-                // the viewport so no gap is left where the closed window used to be.
-                fill_gap(&mut action_socket, move_on_close, windows.len())?;
+                // If the -M / --move-on-close arg is passed and the closed window wasn't
+                // in the leftmost column, force niri to rescroll the viewport so no
+                // gap is left where the closed window used to be.
+                fill_gap(
+                    &mut action_socket,
+                    move_on_close,
+                    closed_window_was_leftmost,
+                    windows.len(),
+                )?;
 
                 // Skip if the -F / --first-only arg is passed
                 if first_only {

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,8 +39,8 @@ struct Args {
     #[arg(short = 'E', long)]
     edges_maximizing: bool,
 
-    #[arg(short = 'S', long)]
-    fill_screen_space: bool,
+    #[arg(short = 'R', long)]
+    reclaim_space: bool,
 
     #[arg(short = 'H', long, default_value_t = 150)]
     height_tolerance: i32,
@@ -108,8 +108,8 @@ fn main() -> anyhow::Result<()> {
     }
 
     // Run in "fill-screen-space" mode if the -S / --fill-screen-space arg is passed
-    let fill_screen_space = args.fill_screen_space;
-    if fill_screen_space {
+    let reclaim_space = args.reclaim_space;
+    if reclaim_space {
         info!(
             "Running in fill-screen-space mode: Fill empty screen space left by closed windows with remaining windows"
         );
@@ -307,7 +307,7 @@ fn main() -> anyhow::Result<()> {
 
                 // If running in "fill-screen-space" mode, nudge the focus to close any empty space
                 // left by closed windows (if needed)
-                if fill_screen_space && !closed_window_was_leftmost && windows.len() > 1 {
+                if reclaim_space && !closed_window_was_leftmost && windows.len() > 1 {
                     nudge_focus(&mut action_socket)?;
                 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -304,12 +304,13 @@ fn main() -> anyhow::Result<()> {
                 // If the -M / --move-on-close arg is passed and the closed window wasn't
                 // in the leftmost column, force niri to rescroll the viewport so no
                 // gap is left where the closed window used to be.
-                fill_gap(
-                    &mut action_socket,
-                    move_on_close,
-                    closed_window_was_leftmost,
-                    windows.len(),
-                )?;
+                if move_on_close && !closed_window_was_leftmost {
+                    fill_gap(
+                        &mut action_socket,
+                        windows.len(),
+                    )?;
+                }
+
 
                 // Skip if the -F / --first-only arg is passed
                 if first_only {

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,15 +11,15 @@ use std::collections::HashMap;
 use std::io::ErrorKind;
 use std::process;
 
-use crate::screen_space::nudge_focus;
 use crate::maximize_window::maximize_window;
+use crate::screen_space::nudge_focus;
 use crate::size_compare::is_maximized;
 
-mod screen_space;
 mod help;
 mod lockfile;
 mod maximize_window;
 mod outputs_map; // https://github.com/Antiz96/oniri/issues/3
+mod screen_space;
 mod size_compare; // https://github.com/Antiz96/oniri/issues/3
 mod socket_connections;
 mod version;
@@ -110,7 +110,9 @@ fn main() -> anyhow::Result<()> {
     // Run in "fill-screen-space" mode if the -S / --fill-screen-space arg is passed
     let fill_screen_space = args.fill_screen_space;
     if fill_screen_space {
-        info!("Running in fill-screen-space mode: Fill empty screen space left by closed windows with remaining windows");
+        info!(
+            "Running in fill-screen-space mode: Fill empty screen space left by closed windows with remaining windows"
+        );
     }
 
     // Set pixel tolerances for window/output size comparison

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,11 +11,11 @@ use std::collections::HashMap;
 use std::io::ErrorKind;
 use std::process;
 
-use crate::fill_gap::fill_gap;
+use crate::screen_space::nudge_focus;
 use crate::maximize_window::maximize_window;
 use crate::size_compare::is_maximized;
 
-mod fill_gap;
+mod screen_space;
 mod help;
 mod lockfile;
 mod maximize_window;
@@ -39,8 +39,8 @@ struct Args {
     #[arg(short = 'E', long)]
     edges_maximizing: bool,
 
-    #[arg(short = 'M', long)]
-    move_on_close: bool,
+    #[arg(short = 'S', long)]
+    fill_screen_space: bool,
 
     #[arg(short = 'H', long, default_value_t = 150)]
     height_tolerance: i32,
@@ -107,10 +107,10 @@ fn main() -> anyhow::Result<()> {
         info!("Running in edges-maximizing mode: Maximize windows to edges");
     }
 
-    // Run in "move-on-close" mode if the -M / --move-on-close arg is passed
-    let move_on_close = args.move_on_close;
-    if move_on_close {
-        info!("Running in move-on-close mode: Moving the viewport on close to fill remaining gap");
+    // Run in "fill-screen-space" mode if the -S / --fill-screen-space arg is passed
+    let fill_screen_space = args.fill_screen_space;
+    if fill_screen_space {
+        info!("Running in fill-screen-space mode: Fill empty screen space left by closed windows with remaining windows");
     }
 
     // Set pixel tolerances for window/output size comparison
@@ -144,9 +144,9 @@ fn main() -> anyhow::Result<()> {
     while let Ok(event) = read_event() {
         // Check if the closing window sits in the leftmost column, before state.apply()
         // below removes it from the state and this information becomes unreachable (used for the
-        // move-on-close mode).
+        // fill-screen-space mode).
         let closed_window_was_leftmost =
-            matches!(&event, Event::WindowClosed { id } if fill_gap::is_leftmost(&state, *id));
+            matches!(&event, Event::WindowClosed { id } if screen_space::is_leftmost(&state, *id));
 
         // Update state
         // This can be dropped once https://github.com/Antiz96/oniri/issues/3 is resolved
@@ -303,10 +303,10 @@ fn main() -> anyhow::Result<()> {
                 // Update the workspace vector
                 windows.retain(|&wid| wid != id);
 
-                // If running in "move-on-close" mode, nudge the focus to close any leftover gap (if
-                // needed)
-                if move_on_close && !closed_window_was_leftmost {
-                    fill_gap(&mut action_socket, windows.len())?;
+                // If running in "fill-screen-space" mode, nudge the focus to close any empty space
+                // left by closed windows (if needed)
+                if fill_screen_space && !closed_window_was_leftmost {
+                    nudge_focus(&mut action_socket, windows.len())?;
                 }
 
                 // Skip if running in "first only" mode

--- a/src/main.rs
+++ b/src/main.rs
@@ -107,6 +107,7 @@ fn main() -> anyhow::Result<()> {
         info!("Running in edges-maximizing mode: Maximize windows to edges");
     }
 
+    // Run in "move-on-close" mode if the -M / --move-on-close arg is passed
     let move_on_close = args.move_on_close;
     if move_on_close {
         info!("Running in move-on-close mode: Moving the viewport on close to fill remaining gap");
@@ -142,9 +143,10 @@ fn main() -> anyhow::Result<()> {
     // Loop over events
     while let Ok(event) = read_event() {
         // Check if the closing window sits in the leftmost column, before state.apply()
-        // below removes it from the state and this information becomes unreachable.
+        // below removes it from the state and this information becomes unreachable (used for the
+        // move-on-close mode).
         let closed_window_was_leftmost =
-            matches!(&event, Event::WindowClosed { id } if fill_gap::is_leftmost_column(&state, *id));
+            matches!(&event, Event::WindowClosed { id } if fill_gap::is_leftmost(&state, *id));
 
         // Update state
         // This can be dropped once https://github.com/Antiz96/oniri/issues/3 is resolved
@@ -301,18 +303,13 @@ fn main() -> anyhow::Result<()> {
                 // Update the workspace vector
                 windows.retain(|&wid| wid != id);
 
-                // If the -M / --move-on-close arg is passed and the closed window wasn't
-                // in the leftmost column, force niri to rescroll the viewport so no
-                // gap is left where the closed window used to be.
+                // If running in "move-on-close" mode, nudge the focus to close any leftover gap (if
+                // needed)
                 if move_on_close && !closed_window_was_leftmost {
-                    fill_gap(
-                        &mut action_socket,
-                        windows.len(),
-                    )?;
+                    fill_gap(&mut action_socket, windows.len())?;
                 }
 
-
-                // Skip if the -F / --first-only arg is passed
+                // Skip if running in "first only" mode
                 if first_only {
                     continue;
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,9 +11,11 @@ use std::collections::HashMap;
 use std::io::ErrorKind;
 use std::process;
 
+use crate::fill_gap::fill_gap;
 use crate::maximize_window::maximize_window;
 use crate::size_compare::is_maximized;
 
+mod fill_gap;
 mod help;
 mod lockfile;
 mod maximize_window;
@@ -36,6 +38,9 @@ struct Args {
 
     #[arg(short = 'E', long)]
     edges_maximizing: bool,
+
+    #[arg(short = 'M', long)]
+    move_on_close: bool,
 
     #[arg(short = 'H', long, default_value_t = 150)]
     height_tolerance: i32,
@@ -100,6 +105,13 @@ fn main() -> anyhow::Result<()> {
     let edges_maximizing = args.edges_maximizing;
     if edges_maximizing {
         info!("Running in edges-maximizing mode: Maximize windows to edges");
+    }
+
+    let move_on_close = args.move_on_close;
+    if move_on_close {
+        info!(
+            "Running in move-on-close mode: Moving the viewport on window close to fill remaining gap"
+        );
     }
 
     // Set pixel tolerances for window/output size comparison
@@ -285,6 +297,10 @@ fn main() -> anyhow::Result<()> {
 
                 // Update the workspace vector
                 windows.retain(|&wid| wid != id);
+
+                // If the -M / --move-on-close arg is passed, force niri to rescroll
+                // the viewport so no gap is left where the closed window used to be.
+                fill_gap(&mut action_socket, move_on_close, windows.len())?;
 
                 // Skip if the -F / --first-only arg is passed
                 if first_only {

--- a/src/screen_space.rs
+++ b/src/screen_space.rs
@@ -19,11 +19,7 @@ pub fn is_leftmost(state: &EventStreamState, window_id: u64) -> bool {
     column == 1
 }
 
-pub fn nudge_focus(socket: &mut Socket, remaining_windows: usize) -> anyhow::Result<()> {
-    if remaining_windows <= 1 {
-        return Ok(());
-    }
-
+pub fn nudge_focus(socket: &mut Socket) -> anyhow::Result<()> {
     let _ = socket.send(Request::Action(Action::FocusColumnLeft {}));
     let _ = socket.send(Request::Action(Action::FocusColumnRight {}));
 

--- a/src/screen_space.rs
+++ b/src/screen_space.rs
@@ -1,5 +1,5 @@
-//! Nudge focus left/right after a window closes, forcing niri to rescroll
-//! the viewport and eliminate any leftover gap on the edge of the screen.
+//! Nudge focus left/right after a window closes, forcing niri to rescroll the viewport
+//! eliminate any leftover gap on the edge of the screen to fill available screen space.
 
 use log::info;
 use niri_ipc::state::EventStreamState;
@@ -19,7 +19,7 @@ pub fn is_leftmost(state: &EventStreamState, window_id: u64) -> bool {
     column == 1
 }
 
-pub fn fill_gap(socket: &mut Socket, remaining_windows: usize) -> anyhow::Result<()> {
+pub fn nudge_focus(socket: &mut Socket, remaining_windows: usize) -> anyhow::Result<()> {
     if remaining_windows <= 1 {
         return Ok(());
     }


### PR DESCRIPTION
Hey! Thanks for the great tool. I would like to add a new `-R` / `--reclaim-space` CLI argument.

Sometimes after closing a few windows from the right side of the screen there's a gap remaining as niri would only move the viewport to fill it with another window **once**. I'm not the biggest fan of this behavior as I don't really want an unused space on my display (if there are still windows outside the viewport), so I (with help from artificial intelligence) made a simple hack to just automatically perform `FocusColumnLeft + FocusColumnRight` after closing a window. It's kinda silly, but gets the job done and I couldn't really find a better solution.

Let me know if I worded it too poorly so I record a video.