### PR TITLE
fix: Fix window and column check with the -R / --reclaim-space option

### DIFF
--- a/src/screen_space.rs
+++ b/src/screen_space.rs
@@ -6,15 +6,13 @@ use niri_ipc::state::EventStreamState;
 use niri_ipc::{Action, Request, socket::Socket};
 
 pub fn is_leftmost(state: &EventStreamState, window_id: u64) -> bool {
-    let window = state
-        .windows
-        .windows
-        .get(&window_id)
-        .expect("Window ID not found in state");
-    let (column, _) = window
-        .layout
-        .pos_in_scrolling_layout
-        .expect("Window has no position in scrolling layout");
+    let Some(window) = state.windows.windows.get(&window_id) else {
+        return false;
+    };
+
+    let Some((column, _)) = window.layout.pos_in_scrolling_layout else {
+        return false;
+    };
 
     column == 1
 }


### PR DESCRIPTION
### Description

Fix a bug introduced in
https://github.com/Antiz96/oniri/pull/93/changes/a40335bd344484fd5625cfcc594c1f49b07bd08d which wrongly treated the window and associated column as non-optional (panicking otherwise).

As it turns out, a window can be associated to no column (resulting in a panic / crash). For instance floating windows (even brief ones, like the Discord starting window).

Therefore, we now treat column as optional, as it was the case initially (and also window while we're at it... Those cannot be non-existent conceptually, but we never know and that makes the logic consistent).
