### PR TITLE
fix: Properly retain lockfile

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -71,7 +71,7 @@ fn main() {
     // Create (if needed) and acquire lockfile
     // Exit if there's already an instance running
     // or if there was an issue creating or acquiring the lockfile (e.g. permission issue)
-    lockfile::acquire_lockfile().unwrap_or_else(|error| {
+    let _lockfile = lockfile::acquire_lockfile().unwrap_or_else(|error| {
         error!("{error:?}");
         process::exit(1);
     });


### PR DESCRIPTION
### Description

Fix a bug causing the lockfile to be immediately released after being acquired, unexpectedly allowing multiple instances to run at the same time.

Regression introduced in https://github.com/Antiz96/oniri/commit/a0223e0a50ef734478bde63c2d81430ee7261a48